### PR TITLE
MacOS support on RC2

### DIFF
--- a/console/main.js
+++ b/console/main.js
@@ -26,13 +26,15 @@ let midiInput = new midi.Input();
 /**
  * Reads the config file and returns the JSON inside
  */
-async function readConfig(defaultConfig) {
+async function readConfig(readConfig, defaultConfig) {
     // Check for existing config file
     if (!fs.existsSync(configPath)) {
         console.warn("No config.json file found, creating default at " + configPath);
         try {
             fs.writeFileSync(configPath, JSON.stringify(defaultConfig, null, 4));
-            return defaultConfig;
+            
+            const configJson = fs.readFileSync(configPath, { encoding: 'utf8', flag: 'r' });
+            return configJson;
         }
         catch (e) {
             console.error("Failed to write default config file " + configPath + "!");


### PR DESCRIPTION
Fixed a problem on MacOS where radios could not be added. Added a channel in the main.js function that clears up the problem. Also fixed a downstream problem this created where config wouldn't load correctly on first startup but reworking some code in main.js readConfig (under if config.json does not exist.)