### PR TITLE
handle overriding of alert tone PTT signals

### DIFF
--- a/console/client.js
+++ b/console/client.js
@@ -162,6 +162,12 @@ var audio_playing = false;
 // Flag to unmute the mic on receipt of a startTx ACK from the radio
 var txUnmuteMic = false;
 
+// Whether the alert tones are currently playing
+var alertTonesInProgress = false;
+
+// Whether the alert PTT has been overridden by a normal PTT
+var alertPttOverride = false;
+
 // Timeout that starts alert tone transmit
 var alertStartTimeout = null;
 
@@ -323,7 +329,14 @@ $(document).on("keydown", function (e) {
         // Spacebar
         case 32:
             e.preventDefault();
-            startPtt(true);
+            // Start PTT if not already TXing
+            if (!pttActive) {
+                startPtt(true);
+            }
+            // Handle alert tone override
+            else if (pttActive && alertTonesInProgress) {
+                startPtt(false);
+            }
             break;
     }
 });
@@ -394,6 +407,11 @@ window.electronAPI.serialPortStatus((event, status) => {
             console.debug("Serial port CTS triggering PTT");
             startPtt(true);
         }
+        // Handle alert tone PTT override case
+        else if (status.cts && pttActive && alertTonesInProgress)
+        {
+            startPtt();
+        }
         // Stop if we need to
         else if (!status.cts && pttActive)
         {
@@ -427,11 +445,18 @@ window.electronAPI.gotMidiMessage((event, msg) => {
     // Check master PTT
     if (midiConfig.ccs.masterPtt.chan == msg.chan && midiConfig.ccs.masterPtt.num == msg.num)
     {
+        // handle Midi Keyup
         if (msg.type == midiMsgTypes.NOTE_ON && !pttActive)
         {
             console.debug("Starting PTT from MIDI master PTT note on");
             startPtt(true);
         }
+        // Handle alert tone override case
+        else if (msg.type == midiMsgTypes.NOTE_ON && pttActive && alertTonesInProgress)
+        {
+            startPtt(false);
+        }
+        // Handle MIDI dekey
         else if (msg.type == midiMsgTypes.NOTE_OFF && pttActive)
         {
             console.debug("Stopping PTT from MIDI master PTT note off");
@@ -836,6 +861,9 @@ function startPtt(micActive) {
     } else if (!pttActive && !selectedRadio) {
         pttActive = true;
         console.log("No radio selected, ignoring PTT");
+    } else if (pttActive && alertTonesInProgress) {
+        alertPttOverride = true;
+        console.warn("PTT overriding alert tone PTT timeout");
     }
 }
 
@@ -1077,8 +1105,18 @@ function dialNumber(radioId, number, digitTime, delayTime) {
 }
 
 function startAlert(mode) {
-    // Start PTT
-    startPtt(false);
+    // Bonk if no radio is selected
+    if (!selectedRadio) {
+        bonk();
+    }
+    // Start PTT if we need to, otherwise PTT was overridden
+    if (!pttActive) {
+        startPtt(false);
+    } else {
+        alertPttOverride = true;
+    }
+    // Set flag
+    alertTonesInProgress = true;
     // Set and start tone gen
     switch (mode) {
         case 1:
@@ -1130,13 +1168,19 @@ function stopAlert() {
         audio.tones.stop();
         // Re-enable the mic
         setTimeout(unmuteMic, audio.micUnmuteDelay + 100);
-        // We wait 5 seconds after the release of the alert button before releasing PTT
-        alertStopTimeout = setTimeout(() => {
-            stopPtt();
-            alertStopTimeout = null;
-        }, 5000);
+        // Only start the 5 second timer if we haven't been overridden
+        if (!alertPttOverride) {
+            // We wait 5 seconds after the release of the alert button before releasing PTT
+            alertStopTimeout = setTimeout(() => {
+                stopPtt();
+                alertStopTimeout = null;
+            }, 5000);
+        } else {
+            alertPttOverride = false;
+        }
     }
-    
+    // Clear flag
+    alertTonesInProgress = false;
 }
 
 /***********************************************************************************
@@ -2259,6 +2303,13 @@ function playSound(soundId) {
 }
 
 /**
+ * Play the error sound
+ */
+function bonk() {
+    playSound("sound-error");
+}
+
+/**
  * Updates the audio parameters for each radio audio source based on current config and selected radio
  */
  function updateRadioAudio() {
@@ -3026,10 +3077,22 @@ function recvExtensionMessage(event) {
                 break;
             // Key radio
             case "keyRadio":
-                if (selectedRadioIdx != value) {
-                    selectRadio(`radio${value}`);
+                if (!pttActive) {
+                    // Select the radio if it isn't
+                    if (selectedRadioIdx != value) {
+                        selectRadio(`radio${value}`);
+                    }
+                    // Start PTT
+                    startPtt(true);
                 }
-                startPtt(true);
+                // Handle alert tone override
+                else if (pttActive && selectedRadioIdx == value && alertTonesInProgress) {
+                    startPtt(false);
+                }
+                // Bonk otherwise (presumably another radio is PTTing)
+                else {
+                    bonk();
+                }
                 break;
             // Dekey radio
             case "dekeyRadio":


### PR DESCRIPTION
PTT events no longer conflict with alert tone transmissions and are handled as you would expect

- Alert tones sent after a user PTT is started do not trigger the 5 second alert voice timeout
- A user PTT during an alert tone will override the 5 second alert voice timeout

Handling of user PTTs during the voice timeout period was already handled properly. This just extends the functionality to before & during alert tone events.