### PR TITLE
feat(daemon): add VOX control mode

### DIFF
--- a/daemon/Configuration.cs
+++ b/daemon/Configuration.cs
@@ -60,6 +60,10 @@ namespace daemon
         /// Config for motorola SB9600
         /// </summary>
         public MotoSb9600Config Sb9600 = new MotoSb9600Config();
+        /// <summary>
+        /// Config for VOX audio-level based control
+        /// </summary>
+        public VoxConfig Vox = new VoxConfig();
     }
 
     /// <summary>

--- a/daemon/LocalAudio.cs
+++ b/daemon/LocalAudio.cs
@@ -47,6 +47,10 @@ namespace daemon
         // RX Audio Objects
         private SDL2AudioSource rxSource;
         private AudioEncoder rxEncoder;
+        private AudioEncoder rxMonitorEncoder;
+        private AudioFormat rxAudioFormat = AudioFormat.Empty;
+        private long lastRawRxSampleMs = long.MinValue;
+        private bool started = false;
 
         // TX Audio Objects
         private SDL2AudioEndPoint txEndpoint;
@@ -60,6 +64,8 @@ namespace daemon
 
         // RX audio callback action
         public Action<uint, byte[]> RxEncodedSampleCallback;
+        public Action<AudioSamplingRatesEnum, uint, short[]> RxRawSampleCallback;
+        public Action<short[]> TxPcmSampleCallback;
 
         public LocalAudio(string rxDevice, string txDevice, rc2_core.Radio radio, bool rxOnly = false)
         {
@@ -76,6 +82,7 @@ namespace daemon
 
             // Setup RX audio devices
             rxEncoder = new AudioEncoder();
+            rxMonitorEncoder = new AudioEncoder();
             rxSource = new SDL2AudioSource(rxDevice, rxEncoder);
             rxSource.OnAudioSourceError += (e) => {
                 Log.Logger.Error("Got RX audio error: {error}", e);
@@ -83,7 +90,17 @@ namespace daemon
             // Setup RX sample callback
             rxSource.OnAudioSourceEncodedSample += (uint durationRtpUnits, byte[] samples) => {
                 //Log.Logger.Verbose("Got {count} encoded RX samples", samples.Length);
-                RxEncodedSampleCallback(durationRtpUnits, samples);
+                RxEncodedSampleCallback?.Invoke(durationRtpUnits, samples);
+                if (RxRawSampleCallback != null && Environment.TickCount64 - lastRawRxSampleMs > 1000 && rxAudioFormat.ClockRate > 0)
+                {
+                    short[] pcmSamples = rxMonitorEncoder.DecodeAudio(samples, rxAudioFormat);
+                    uint durationMilliseconds = (uint)(pcmSamples.Length * 1000 / rxAudioFormat.ClockRate);
+                    RxRawSampleCallback(AudioSamplingRatesEnum.Rate16KHz, durationMilliseconds, pcmSamples);
+                }
+            };
+            rxSource.OnAudioSourceRawSample += (AudioSamplingRatesEnum samplingRate, uint durationMilliseconds, short[] samples) => {
+                lastRawRxSampleMs = Environment.TickCount64;
+                RxRawSampleCallback?.Invoke(samplingRate, durationMilliseconds, samples);
             };
             Log.Logger.Information("    RX: {rxDevice}", rxDevice);
             // Setup TX audio devices if we aren't rx-only
@@ -101,6 +118,13 @@ namespace daemon
 
         public void Start(AudioFormat audioFormat)
         {
+            if (started)
+            {
+                Log.Logger.Debug("Audio device(s) already started, keeping existing format {format}/{rate}/{chans}", rxAudioFormat.FormatName, rxAudioFormat.ClockRate, rxAudioFormat.ChannelCount);
+                return;
+            }
+
+            rxAudioFormat = audioFormat;
             // Set audio formats
             rxSource.SetAudioSourceFormat(audioFormat);
             if (!rxOnly)
@@ -114,14 +138,18 @@ namespace daemon
                 txEndpoint.StartAudioSink();
             }
             Log.Logger.Debug("Audio device(s) started using format {format}/{rate}/{chans}", audioFormat.FormatName, audioFormat.ClockRate, audioFormat.ChannelCount);
+            started = true;
         }
 
         public async Task Stop()
         {
-            await rxSource.CloseAudio();
-            if (!rxOnly)
+            if (started)
             {
-                await txEndpoint.CloseAudioSink();
+                await rxSource.CloseAudio();
+                if (!rxOnly)
+                {
+                    await txEndpoint.CloseAudioSink();
+                }
             }
             // De-init SDL2
             SDL2Helper.QuitSDL();
@@ -132,6 +160,7 @@ namespace daemon
         {
             // Do nothing if we're RX only
             if (rxOnly) { return; }
+            TxPcmSampleCallback?.Invoke(pcm16Samples);
             // Convert the short[] samples into byte[] samples
             byte[] pcm16Bytes = new byte[pcm16Samples.Length * 2];
             Buffer.BlockCopy(pcm16Samples, 0, pcm16Bytes, 0, pcm16Samples.Length * 2);

--- a/daemon/Program.cs
+++ b/daemon/Program.cs
@@ -202,6 +202,34 @@ namespace netcore_cli
             // Switch based on control mode
             switch(Config.Control.ControlMode)
             {
+                case RadioControlMode.VOX:
+                {
+                    VoxRadio voxRadio = null;
+                    Action<AudioFormat> rtcFormatCallback = (audioFormat) =>
+                    {
+                        localAudio.Start(audioFormat);
+                        voxRadio?.ReArmStartupDelay("WebRTC audio negotiation");
+                    };
+
+                    voxRadio = new VoxRadio(
+                        Config.Daemon.Name,
+                        Config.Daemon.Desc,
+                        Config.Control.RxOnly,
+                        Config.Daemon.ListenAddress,
+                        Config.Daemon.ListenPort,
+                        Config.Control.Vox,
+                        localAudio.TxAudioCallback,
+                        16000,
+                        rtcFormatCallback,
+                        Config.Softkeys,
+                        Config.TextLookups.Zone,
+                        Config.TextLookups.Channel
+                    );
+                    radio = voxRadio;
+                    localAudio.RxRawSampleCallback += voxRadio.HandleRxAudioSamples;
+                    localAudio.TxPcmSampleCallback += voxRadio.HandleTxAudioSamples;
+                }
+                break;
                 case RadioControlMode.SB9600:
                 {
                     radio = new MotoSb9600Radio(
@@ -229,7 +257,15 @@ namespace netcore_cli
             }
 
             // Setup RX audio callback
-            localAudio.RxEncodedSampleCallback += radio.RxSendEncodedSamples;
+            if (Config.Control.ControlMode == RadioControlMode.VOX)
+            {
+                localAudio.RxEncodedSampleCallback += ((VoxRadio)radio).HandleRxEncodedSamples;
+                localAudio.Start(GetDefaultAudioFormat());
+            }
+            else
+            {
+                localAudio.RxEncodedSampleCallback += radio.RxSendEncodedSamples;
+            }
 
             // Start radio
             radio.Start(noreset);
@@ -330,6 +366,20 @@ namespace netcore_cli
                 Log.Information("        {codec}", codec.FormatName);
             }
             SDL2Helper.QuitSDL();
+        }
+
+        static AudioFormat GetDefaultAudioFormat()
+        {
+            AudioEncoder audioEncoder = new AudioEncoder();
+            AudioFormat g722 = audioEncoder.SupportedFormats.Find(f => f.FormatName == "G722");
+
+            if (g722.ClockRate == 0)
+            {
+                var audioFormatManager = new MediaFormatManager<AudioFormat>(audioEncoder.SupportedFormats);
+                return audioFormatManager.SelectedFormat;
+            }
+
+            return g722;
         }
     }
 }

--- a/daemon/Radio.VOX.cs
+++ b/daemon/Radio.VOX.cs
@@ -1,0 +1,510 @@
+using rc2_core;
+using Serilog;
+using SIPSorceryMedia.Abstractions;
+using System.Net;
+
+namespace daemon
+{
+    /// <summary>
+    /// Config object used to parse YML config for VOX control.
+    /// </summary>
+    public class VoxConfig
+    {
+        /// <summary>
+        /// Static zone name shown in the console for VOX radios.
+        /// </summary>
+        public string ZoneName = "VOX";
+        /// <summary>
+        /// Static channel name shown in the console for VOX radios.
+        /// </summary>
+        public string ChannelName = "Audio";
+        /// <summary>
+        /// RX audio level, in dBFS, required to mark the radio receiving.
+        /// </summary>
+        public double RxThresholdDb = -45.0;
+        /// <summary>
+        /// TX audio level, in dBFS, required to mark the radio transmitting.
+        /// </summary>
+        public double TxThresholdDb = -45.0;
+        /// <summary>
+        /// Audio must remain above threshold for this many milliseconds before the gate opens.
+        /// </summary>
+        public int AttackMs = 80;
+        /// <summary>
+        /// The gate remains open this many milliseconds after audio drops below threshold.
+        /// </summary>
+        public int HangMs = 800;
+        /// <summary>
+        /// Audio samples are ignored for this many milliseconds after startup to let devices settle.
+        /// </summary>
+        public int StartupDelayMs = 1000;
+        /// <summary>
+        /// VOX opens only when audio is this many dB above the learned noise floor.
+        /// </summary>
+        public double NoiseMarginDb = 8.0;
+        /// <summary>
+        /// After startup or reconnect, require one quiet sample before the gate can open.
+        /// </summary>
+        public bool RequireQuietAfterReset = true;
+    }
+
+    /// <summary>
+    /// Radio implementation for audio-only installations where TX/RX state is inferred from audio levels.
+    /// </summary>
+    internal sealed class VoxRadio : rc2_core.Radio
+    {
+        private readonly object stateLock = new object();
+        private readonly VoxConfig voxConfig;
+        private readonly VoxGate rxGate;
+        private readonly VoxGate txGate;
+        private readonly bool txDisabled;
+        private readonly System.Timers.Timer hangTimer;
+        private readonly int startupDelayMs;
+        private long ignoreAudioUntilMs;
+        private bool calibrationPending;
+        private bool started;
+
+        public VoxRadio(
+            string name, string desc, bool rxOnly,
+            IPAddress listenAddress, int listenPort,
+            VoxConfig voxConfig,
+            Action<short[]> txAudioCallback, int txAudioSampleRate, Action<AudioFormat> rtcFormatCallback,
+            List<SoftkeyName> softkeys,
+            List<TextLookup> zoneLookups = null, List<TextLookup> chanLookups = null
+            ) : base(name, desc, rxOnly, listenAddress, listenPort, softkeys, zoneLookups, chanLookups, txAudioCallback, txAudioSampleRate, rtcFormatCallback)
+        {
+            this.voxConfig = voxConfig ?? new VoxConfig();
+            txDisabled = rxOnly;
+            RxOnly = rxOnly;
+            startupDelayMs = Math.Max(0, this.voxConfig.StartupDelayMs);
+
+            rxGate = new VoxGate(
+                this.voxConfig.RxThresholdDb,
+                this.voxConfig.NoiseMarginDb,
+                this.voxConfig.RequireQuietAfterReset,
+                Math.Max(0, this.voxConfig.AttackMs),
+                Math.Max(1, this.voxConfig.HangMs));
+            txGate = new VoxGate(
+                this.voxConfig.TxThresholdDb,
+                this.voxConfig.NoiseMarginDb,
+                this.voxConfig.RequireQuietAfterReset,
+                Math.Max(0, this.voxConfig.AttackMs),
+                Math.Max(1, this.voxConfig.HangMs));
+
+            Status.ZoneName = this.voxConfig.ZoneName;
+            Status.ChannelName = this.voxConfig.ChannelName;
+
+            hangTimer = new System.Timers.Timer(Math.Clamp(this.voxConfig.HangMs / 4, 50, 250));
+            hangTimer.AutoReset = true;
+            hangTimer.Elapsed += (sender, args) => ExpireGates();
+        }
+
+        public override void Start(bool reset = false)
+        {
+            Log.Information("Starting new VOX radio instance");
+            base.Start(reset);
+
+            lock (stateLock)
+            {
+                started = true;
+                rxGate.Reset();
+                txGate.Reset();
+                Status.ZoneName = voxConfig.ZoneName;
+                Status.ChannelName = voxConfig.ChannelName;
+                Status.State = RadioState.Idle;
+                ArmWarmup(Environment.TickCount64);
+            }
+
+            if (startupDelayMs > 0)
+            {
+                Log.Debug("VOX startup delay active for {delay} ms", startupDelayMs);
+            }
+
+            hangTimer.Start();
+            RadioStatusCallback();
+        }
+
+        public void ReArmStartupDelay(string reason)
+        {
+            bool statusChanged = false;
+
+            lock (stateLock)
+            {
+                ArmWarmup(Environment.TickCount64);
+
+                if (started && Status.State != RadioState.Idle)
+                {
+                    Status.State = RadioState.Idle;
+                    statusChanged = true;
+                }
+            }
+
+            if (startupDelayMs > 0)
+            {
+                Log.Debug("VOX startup delay re-armed for {delay} ms ({reason})", startupDelayMs, reason);
+            }
+            else
+            {
+                Log.Debug("VOX gates reset ({reason})", reason);
+            }
+
+            if (statusChanged)
+            {
+                RadioStatusCallback();
+            }
+        }
+
+        public override void Stop()
+        {
+            hangTimer.Stop();
+
+            lock (stateLock)
+            {
+                started = false;
+                Status.State = RadioState.Disconnected;
+            }
+
+            RadioStatusCallback();
+            base.Stop();
+        }
+
+        public override bool SetTransmit(bool tx)
+        {
+            if (tx && txDisabled)
+            {
+                Log.Warning("Ignoring VOX transmit request because this radio is RX-only");
+                return false;
+            }
+
+            Log.Debug("Acknowledging VOX transmit {state}; radio state will follow TX audio level", tx ? "start" : "stop");
+            return true;
+        }
+
+        public override bool ChangeChannel(bool down)
+        {
+            Log.Debug("Ignoring channel change request because VOX control has no channel interface");
+            return false;
+        }
+
+        public override bool PressButton(SoftkeyName name)
+        {
+            Log.Debug("Ignoring button press {name} because VOX control has no button interface", name);
+            return false;
+        }
+
+        public override bool ReleaseButton(SoftkeyName name)
+        {
+            Log.Debug("Ignoring button release {name} because VOX control has no button interface", name);
+            return false;
+        }
+
+        public void HandleRxAudioSamples(AudioSamplingRatesEnum samplingRate, uint durationMilliseconds, short[] samples)
+        {
+            ProcessSamples(rxGate, samples, "RX");
+        }
+
+        public void HandleTxAudioSamples(short[] samples)
+        {
+            if (txDisabled)
+            {
+                return;
+            }
+
+            ProcessSamples(txGate, samples, "TX");
+        }
+
+        public void HandleRxEncodedSamples(uint durationRtpUnits, byte[] encodedSamples)
+        {
+            bool shouldForward;
+
+            lock (stateLock)
+            {
+                shouldForward = started && Status.State == RadioState.Receiving;
+            }
+
+            if (!shouldForward)
+            {
+                return;
+            }
+
+            RxSendEncodedSamples(durationRtpUnits, encodedSamples);
+        }
+
+        private void ProcessSamples(VoxGate gate, short[] samples, string direction)
+        {
+            if (samples == null || samples.Length == 0)
+            {
+                return;
+            }
+
+            long nowMs = Environment.TickCount64;
+            double levelDb = CalculateRmsDb(samples);
+            RadioState nextState = RadioState.Idle;
+            bool statusChanged = false;
+
+            lock (stateLock)
+            {
+                if (!started)
+                {
+                    return;
+                }
+
+                if (nowMs < ignoreAudioUntilMs)
+                {
+                    gate.Calibrate(levelDb);
+                    if (Status.State != RadioState.Idle)
+                    {
+                        Status.State = RadioState.Idle;
+                        statusChanged = true;
+                    }
+                }
+            }
+
+            if (nowMs < ignoreAudioUntilMs)
+            {
+                if (statusChanged)
+                {
+                    RadioStatusCallback();
+                }
+
+                return;
+            }
+
+            lock (stateLock)
+            {
+                if (!started)
+                {
+                    return;
+                }
+
+                CompleteWarmup();
+                gate.Process(levelDb, nowMs);
+                nextState = GetVoxState();
+                if (Status.State != nextState)
+                {
+                    Status.State = nextState;
+                    statusChanged = true;
+                }
+            }
+
+            if (statusChanged)
+            {
+                Log.Debug("VOX {direction} level {level:0.0} dBFS changed radio state to {state}", direction, levelDb, nextState);
+                RadioStatusCallback();
+            }
+        }
+
+        private void ExpireGates()
+        {
+            RadioState nextState = RadioState.Idle;
+            bool statusChanged = false;
+
+            lock (stateLock)
+            {
+                if (!started)
+                {
+                    return;
+                }
+
+                long nowMs = Environment.TickCount64;
+
+                if (nowMs < ignoreAudioUntilMs)
+                {
+                    if (Status.State != RadioState.Idle)
+                    {
+                        Status.State = RadioState.Idle;
+                        statusChanged = true;
+                    }
+
+                    nextState = RadioState.Idle;
+                }
+                else
+                {
+                    CompleteWarmup();
+                    rxGate.Expire(nowMs);
+                    txGate.Expire(nowMs);
+
+                    nextState = GetVoxState();
+                    if (Status.State != nextState)
+                    {
+                        Status.State = nextState;
+                        statusChanged = true;
+                    }
+                }
+            }
+
+            if (statusChanged)
+            {
+                Log.Debug("VOX hang timer changed radio state to {state}", nextState);
+                RadioStatusCallback();
+            }
+        }
+
+        private RadioState GetVoxState()
+        {
+            if (!txDisabled && txGate.Active)
+            {
+                return RadioState.Transmitting;
+            }
+
+            if (rxGate.Active)
+            {
+                return RadioState.Receiving;
+            }
+
+            return RadioState.Idle;
+        }
+
+        private void ArmWarmup(long nowMs)
+        {
+            rxGate.Reset();
+            txGate.Reset();
+            ignoreAudioUntilMs = nowMs + startupDelayMs;
+            calibrationPending = true;
+        }
+
+        private void CompleteWarmup()
+        {
+            if (!calibrationPending)
+            {
+                return;
+            }
+
+            calibrationPending = false;
+            rxGate.CompleteCalibration();
+            txGate.CompleteCalibration();
+            Log.Debug(
+                "VOX calibration complete: RX floor {rxFloor:0.0} dBFS, RX effective threshold {rxThreshold:0.0} dBFS; TX floor {txFloor:0.0} dBFS, TX effective threshold {txThreshold:0.0} dBFS",
+                rxGate.NoiseFloorDb,
+                rxGate.EffectiveThresholdDb,
+                txGate.NoiseFloorDb,
+                txGate.EffectiveThresholdDb);
+        }
+
+        private static double CalculateRmsDb(short[] samples)
+        {
+            double sumSquares = 0.0;
+
+            foreach (short sample in samples)
+            {
+                double normalized = sample / 32768.0;
+                sumSquares += normalized * normalized;
+            }
+
+            double rms = Math.Sqrt(sumSquares / samples.Length);
+            if (rms <= 0.0)
+            {
+                return double.NegativeInfinity;
+            }
+
+            return 20.0 * Math.Log10(rms);
+        }
+
+        private sealed class VoxGate
+        {
+            private readonly double thresholdDb;
+            private readonly double noiseMarginDb;
+            private readonly bool requireQuietAfterReset;
+            private readonly int attackMs;
+            private readonly int hangMs;
+            private long? aboveThresholdSinceMs;
+            private long lastAboveThresholdMs = long.MinValue;
+            private double calibrationSumDb;
+            private int calibrationCount;
+            private bool waitingForQuiet;
+
+            public bool Active { get; private set; }
+            public double NoiseFloorDb { get; private set; } = double.NegativeInfinity;
+            public double EffectiveThresholdDb
+            {
+                get
+                {
+                    if (double.IsNegativeInfinity(NoiseFloorDb))
+                    {
+                        return thresholdDb;
+                    }
+
+                    return Math.Max(thresholdDb, NoiseFloorDb + noiseMarginDb);
+                }
+            }
+
+            public VoxGate(double thresholdDb, double noiseMarginDb, bool requireQuietAfterReset, int attackMs, int hangMs)
+            {
+                this.thresholdDb = thresholdDb;
+                this.noiseMarginDb = noiseMarginDb;
+                this.requireQuietAfterReset = requireQuietAfterReset;
+                this.attackMs = attackMs;
+                this.hangMs = hangMs;
+            }
+
+            public void Calibrate(double levelDb)
+            {
+                if (double.IsNegativeInfinity(levelDb) || double.IsNaN(levelDb))
+                {
+                    return;
+                }
+
+                calibrationSumDb += levelDb;
+                calibrationCount++;
+            }
+
+            public void CompleteCalibration()
+            {
+                if (calibrationCount > 0)
+                {
+                    NoiseFloorDb = calibrationSumDb / calibrationCount;
+                }
+            }
+
+            public void Process(double levelDb, long nowMs)
+            {
+                double effectiveThresholdDb = EffectiveThresholdDb;
+
+                if (waitingForQuiet)
+                {
+                    if (levelDb < effectiveThresholdDb)
+                    {
+                        waitingForQuiet = false;
+                    }
+
+                    return;
+                }
+
+                if (levelDb >= effectiveThresholdDb)
+                {
+                    lastAboveThresholdMs = nowMs;
+                    aboveThresholdSinceMs ??= nowMs;
+
+                    if (!Active && nowMs - aboveThresholdSinceMs.Value >= attackMs)
+                    {
+                        Active = true;
+                    }
+
+                    return;
+                }
+
+                aboveThresholdSinceMs = null;
+                Expire(nowMs);
+            }
+
+            public void Expire(long nowMs)
+            {
+                if (Active && lastAboveThresholdMs != long.MinValue && nowMs - lastAboveThresholdMs >= hangMs)
+                {
+                    Active = false;
+                    aboveThresholdSinceMs = null;
+                }
+            }
+
+            public void Reset()
+            {
+                Active = false;
+                aboveThresholdSinceMs = null;
+                lastAboveThresholdMs = long.MinValue;
+                calibrationSumDb = 0.0;
+                calibrationCount = 0;
+                waitingForQuiet = requireQuietAfterReset;
+            }
+        }
+    }
+}

--- a/daemon/config.example.yml
+++ b/daemon/config.example.yml
@@ -17,7 +17,7 @@ daemon:
 control:
     # Control Mode
     #
-    #   0 - VOX (control of TX/RX states is based on audio levels only) [Not Yet Implemented]
+    #   0 - VOX (control of TX/RX states is based on audio levels only)
     #   1 - TRC (Tone remote control based on EIA tone signalling) [Not Yet Implemented]
     #   2 - SB9600 (emulation of Motorola Astro W-series and MCS2000 model-3 control heads over SB9600)
     #   3 - XCMP Serial (control of Motorola XTL radios via serial)
@@ -26,6 +26,27 @@ control:
 
     # RX Only (TX disabled)
     rxOnly: false
+
+    # VOX configuration
+    vox:
+        # Static zone/channel labels shown by the console
+        zoneName: "VOX"
+        channelName: "Audio"
+        # Audio level in dBFS required to mark RX/TX active.
+        # Less negative is less sensitive; more negative is more sensitive.
+        rxThresholdDb: -45
+        txThresholdDb: -45
+        # Audio must stay above threshold for attackMs before opening,
+        # and stays open for hangMs after dropping below threshold.
+        attackMs: 80
+        hangMs: 800
+        # Ignore audio briefly after startup so USB device-open noise does not trip VOX.
+        startupDelayMs: 1000
+        # During startup/reconnect, learn the idle noise floor and require audio
+        # to exceed it by this margin before opening VOX.
+        noiseMarginDb: 8
+        # After startup/reconnect, require quiet before the next VOX open.
+        requireQuietAfterReset: true
 
     # SB9600 configuration
     sb9600:


### PR DESCRIPTION
Implement audio-level based VOX radio control with RX/TX gate detection,
startup/reconnect suppression, learned noise-floor calibration, and gated
RX forwarding. Wire VOX mode into daemon startup, local audio callbacks,
and example configuration.