### PR TITLE
Vox implementation

### DIFF
--- a/daemon/Configuration.cs
+++ b/daemon/Configuration.cs
@@ -64,6 +64,10 @@ namespace daemon
         /// Config for motorola SB9600
         /// </summary>
         public MotoSb9600Config Sb9600 = new MotoSb9600Config();
+        /// <summary>
+        /// Config for VOX audio-level based control
+        /// </summary>
+        public VoxConfig Vox = new VoxConfig();
     }
 
     /// <summary>

--- a/daemon/LocalAudio.cs
+++ b/daemon/LocalAudio.cs
@@ -65,7 +65,6 @@ namespace daemon
         // RX audio callback action
         public Action<uint, byte[]> RxEncodedSampleCallback;
         public Action<AudioSamplingRatesEnum, uint, short[]> RxRawSampleCallback;
-        public Action<short[]> TxPcmSampleCallback;
 
         public LocalAudio(string rxDevice, string txDevice, rc2_core.Radio radio, bool rxOnly = false)
         {
@@ -160,7 +159,6 @@ namespace daemon
         {
             // Do nothing if we're RX only
             if (rxOnly) { return; }
-            TxPcmSampleCallback?.Invoke(pcm16Samples);
             // Convert the short[] samples into byte[] samples
             byte[] pcm16Bytes = new byte[pcm16Samples.Length * 2];
             Buffer.BlockCopy(pcm16Samples, 0, pcm16Bytes, 0, pcm16Samples.Length * 2);

--- a/daemon/LocalAudio.cs
+++ b/daemon/LocalAudio.cs
@@ -64,6 +64,8 @@ namespace daemon
 
         // RX audio callback action
         public Action<uint, byte[]> RxEncodedSampleCallback;
+        // Optional raw PCM monitor used by VOX mode to detect RX activity without
+        // changing the encoded audio path used by normal radios.
         public Action<AudioSamplingRatesEnum, uint, short[]> RxRawSampleCallback;
 
         public LocalAudio(string rxDevice, string txDevice, rc2_core.Radio radio, bool rxOnly = false)
@@ -92,6 +94,9 @@ namespace daemon
                 RxEncodedSampleCallback?.Invoke(durationRtpUnits, samples);
                 if (RxRawSampleCallback != null && Environment.TickCount64 - lastRawRxSampleMs > 1000 && rxAudioFormat.ClockRate > 0)
                 {
+                    // Some SDL backends only provide encoded callbacks. Decode a monitor
+                    // copy so VOX still receives audio levels, but rate-limit it behind
+                    // direct raw callbacks to avoid duplicate gate updates.
                     short[] pcmSamples = rxMonitorEncoder.DecodeAudio(samples, rxAudioFormat);
                     uint durationMilliseconds = (uint)(pcmSamples.Length * 1000 / rxAudioFormat.ClockRate);
                     RxRawSampleCallback(AudioSamplingRatesEnum.Rate16KHz, durationMilliseconds, pcmSamples);
@@ -119,6 +124,9 @@ namespace daemon
         {
             if (started)
             {
+                // VOX can request Start from both initial setup and later WebRTC format
+                // negotiation. Keep the first active device session instead of reopening
+                // SDL devices mid-call.
                 Log.Logger.Debug("Audio device(s) already started, keeping existing format {format}/{rate}/{chans}", rxAudioFormat.FormatName, rxAudioFormat.ClockRate, rxAudioFormat.ChannelCount);
                 return;
             }

--- a/daemon/LocalAudio.cs
+++ b/daemon/LocalAudio.cs
@@ -47,6 +47,10 @@ namespace daemon
         // RX Audio Objects
         private SDL2AudioSource rxSource;
         private AudioEncoder rxEncoder;
+        private AudioEncoder rxMonitorEncoder;
+        private AudioFormat rxAudioFormat = AudioFormat.Empty;
+        private long lastRawRxSampleMs = long.MinValue;
+        private bool started = false;
 
         // TX Audio Objects
         private SDL2AudioEndPoint txEndpoint;
@@ -60,6 +64,8 @@ namespace daemon
 
         // RX audio callback action
         public Action<uint, byte[]> RxEncodedSampleCallback;
+        public Action<AudioSamplingRatesEnum, uint, short[]> RxRawSampleCallback;
+        public Action<short[]> TxPcmSampleCallback;
 
         public LocalAudio(string rxDevice, string txDevice, rc2_core.Radio radio, bool rxOnly = false)
         {
@@ -76,6 +82,7 @@ namespace daemon
 
             // Setup RX audio devices
             rxEncoder = new AudioEncoder();
+            rxMonitorEncoder = new AudioEncoder();
             rxSource = new SDL2AudioSource(rxDevice, rxEncoder);
             rxSource.OnAudioSourceError += (e) => {
                 Log.Logger.Error("Got RX audio error: {error}", e);
@@ -83,7 +90,17 @@ namespace daemon
             // Setup RX sample callback
             rxSource.OnAudioSourceEncodedSample += (uint durationRtpUnits, byte[] samples) => {
                 //Log.Logger.Verbose("Got {count} encoded RX samples", samples.Length);
-                RxEncodedSampleCallback(durationRtpUnits, samples);
+                RxEncodedSampleCallback?.Invoke(durationRtpUnits, samples);
+                if (RxRawSampleCallback != null && Environment.TickCount64 - lastRawRxSampleMs > 1000 && rxAudioFormat.ClockRate > 0)
+                {
+                    short[] pcmSamples = rxMonitorEncoder.DecodeAudio(samples, rxAudioFormat);
+                    uint durationMilliseconds = (uint)(pcmSamples.Length * 1000 / rxAudioFormat.ClockRate);
+                    RxRawSampleCallback(AudioSamplingRatesEnum.Rate16KHz, durationMilliseconds, pcmSamples);
+                }
+            };
+            rxSource.OnAudioSourceRawSample += (AudioSamplingRatesEnum samplingRate, uint durationMilliseconds, short[] samples) => {
+                lastRawRxSampleMs = Environment.TickCount64;
+                RxRawSampleCallback?.Invoke(samplingRate, durationMilliseconds, samples);
             };
             Log.Logger.Information("    RX: {rxDevice}", rxDevice);
             // Setup TX audio devices if we aren't rx-only
@@ -101,6 +118,13 @@ namespace daemon
 
         public void Start(AudioFormat audioFormat)
         {
+            if (started)
+            {
+                Log.Logger.Debug("Audio device(s) already started, keeping existing format {format}/{rate}/{chans}", rxAudioFormat.FormatName, rxAudioFormat.ClockRate, rxAudioFormat.ChannelCount);
+                return;
+            }
+
+            rxAudioFormat = audioFormat;
             // Set audio formats
             rxSource.SetAudioSourceFormat(audioFormat);
             if (!rxOnly)
@@ -114,14 +138,18 @@ namespace daemon
                 txEndpoint.StartAudioSink();
             }
             Log.Logger.Debug("Audio device(s) started using format {format}/{rate}/{chans}", audioFormat.FormatName, audioFormat.ClockRate, audioFormat.ChannelCount);
+            started = true;
         }
 
         public async Task Stop()
         {
-            await rxSource.CloseAudio();
-            if (!rxOnly)
+            if (started)
             {
-                await txEndpoint.CloseAudioSink();
+                await rxSource.CloseAudio();
+                if (!rxOnly)
+                {
+                    await txEndpoint.CloseAudioSink();
+                }
             }
             // De-init SDL2
             SDL2Helper.QuitSDL();
@@ -132,6 +160,7 @@ namespace daemon
         {
             // Do nothing if we're RX only
             if (rxOnly) { return; }
+            TxPcmSampleCallback?.Invoke(pcm16Samples);
             // Convert the short[] samples into byte[] samples
             byte[] pcm16Bytes = new byte[pcm16Samples.Length * 2];
             Buffer.BlockCopy(pcm16Samples, 0, pcm16Bytes, 0, pcm16Samples.Length * 2);

--- a/daemon/Program.cs
+++ b/daemon/Program.cs
@@ -205,6 +205,10 @@ namespace netcore_cli
                 case RadioControlMode.VOX:
                 {
                     VoxRadio voxRadio = null;
+                    Action<short[]> txAudioCallback = (samples) =>
+                    {
+                        voxRadio?.HandleTxAudioSamples(samples);
+                    };
                     Action<AudioFormat> rtcFormatCallback = (audioFormat) =>
                     {
                         localAudio.Start(audioFormat);
@@ -218,6 +222,7 @@ namespace netcore_cli
                         Config.Daemon.ListenAddress,
                         Config.Daemon.ListenPort,
                         Config.Control.Vox,
+                        txAudioCallback,
                         localAudio.TxAudioCallback,
                         16000,
                         rtcFormatCallback,
@@ -227,7 +232,6 @@ namespace netcore_cli
                     );
                     radio = voxRadio;
                     localAudio.RxRawSampleCallback += voxRadio.HandleRxAudioSamples;
-                    localAudio.TxPcmSampleCallback += voxRadio.HandleTxAudioSamples;
                 }
                 break;
                 case RadioControlMode.SB9600:

--- a/daemon/Program.cs
+++ b/daemon/Program.cs
@@ -205,12 +205,16 @@ namespace netcore_cli
                 case RadioControlMode.VOX:
                 {
                     VoxRadio voxRadio = null;
+                    // WebRTC TX audio enters through the base RC2 radio callback. Capture
+                    // the VoxRadio after construction so the callback can feed the TX gate.
                     Action<short[]> txAudioCallback = (samples) =>
                     {
                         voxRadio?.HandleTxAudioSamples(samples);
                     };
                     Action<AudioFormat> rtcFormatCallback = (audioFormat) =>
                     {
+                        // Start local SDL audio using the negotiated WebRTC format, then
+                        // restart VOX warmup so device-open noise is ignored.
                         localAudio.Start(audioFormat);
                         voxRadio?.ReArmStartupDelay("WebRTC audio negotiation");
                     };
@@ -221,6 +225,7 @@ namespace netcore_cli
                         Config.Control.RxOnly,
                         Config.Daemon.ListenAddress,
                         Config.Daemon.ListenPort,
+                        Config.Daemon.AllowedNetworks,
                         Config.Control.Vox,
                         txAudioCallback,
                         localAudio.TxAudioCallback,
@@ -231,6 +236,8 @@ namespace netcore_cli
                         Config.TextLookups.Channel
                     );
                     radio = voxRadio;
+                    // Raw RX samples drive VOX state; encoded RX samples are forwarded
+                    // separately only while VoxRadio reports Receiving.
                     localAudio.RxRawSampleCallback += voxRadio.HandleRxAudioSamples;
                 }
                 break;
@@ -264,6 +271,8 @@ namespace netcore_cli
             // Setup RX audio callback
             if (Config.Control.ControlMode == RadioControlMode.VOX)
             {
+                // VOX needs a default format before a peer negotiates so local RX can
+                // start and begin detecting audio. Re-negotiation may update this later.
                 localAudio.RxEncodedSampleCallback += ((VoxRadio)radio).HandleRxEncodedSamples;
                 localAudio.Start(GetDefaultAudioFormat());
             }

--- a/daemon/Program.cs
+++ b/daemon/Program.cs
@@ -202,6 +202,34 @@ namespace netcore_cli
             // Switch based on control mode
             switch(Config.Control.ControlMode)
             {
+                case RadioControlMode.VOX:
+                {
+                    VoxRadio voxRadio = null;
+                    Action<AudioFormat> rtcFormatCallback = (audioFormat) =>
+                    {
+                        localAudio.Start(audioFormat);
+                        voxRadio?.ReArmStartupDelay("WebRTC audio negotiation");
+                    };
+
+                    voxRadio = new VoxRadio(
+                        Config.Daemon.Name,
+                        Config.Daemon.Desc,
+                        Config.Control.RxOnly,
+                        Config.Daemon.ListenAddress,
+                        Config.Daemon.ListenPort,
+                        Config.Control.Vox,
+                        localAudio.TxAudioCallback,
+                        16000,
+                        rtcFormatCallback,
+                        Config.Softkeys,
+                        Config.TextLookups.Zone,
+                        Config.TextLookups.Channel
+                    );
+                    radio = voxRadio;
+                    localAudio.RxRawSampleCallback += voxRadio.HandleRxAudioSamples;
+                    localAudio.TxPcmSampleCallback += voxRadio.HandleTxAudioSamples;
+                }
+                break;
                 case RadioControlMode.SB9600:
                 {
                     radio = new MotoSb9600Radio(
@@ -230,7 +258,15 @@ namespace netcore_cli
             }
 
             // Setup RX audio callback
-            localAudio.RxEncodedSampleCallback += radio.RxSendEncodedSamples;
+            if (Config.Control.ControlMode == RadioControlMode.VOX)
+            {
+                localAudio.RxEncodedSampleCallback += ((VoxRadio)radio).HandleRxEncodedSamples;
+                localAudio.Start(GetDefaultAudioFormat());
+            }
+            else
+            {
+                localAudio.RxEncodedSampleCallback += radio.RxSendEncodedSamples;
+            }
 
             // Start radio
             radio.Start(noreset);
@@ -331,6 +367,20 @@ namespace netcore_cli
                 Log.Information("        {codec}", codec.FormatName);
             }
             SDL2Helper.QuitSDL();
+        }
+
+        static AudioFormat GetDefaultAudioFormat()
+        {
+            AudioEncoder audioEncoder = new AudioEncoder();
+            AudioFormat g722 = audioEncoder.SupportedFormats.Find(f => f.FormatName == "G722");
+
+            if (g722.ClockRate == 0)
+            {
+                var audioFormatManager = new MediaFormatManager<AudioFormat>(audioEncoder.SupportedFormats);
+                return audioFormatManager.SelectedFormat;
+            }
+
+            return g722;
         }
     }
 }

--- a/daemon/Radio.VOX.cs
+++ b/daemon/Radio.VOX.cs
@@ -60,15 +60,17 @@ namespace daemon
         private readonly bool txDisabled;
         private readonly System.Timers.Timer hangTimer;
         private readonly int startupDelayMs;
+        private readonly Action<short[]> txAudioOutputCallback;
         private long ignoreAudioUntilMs;
         private bool calibrationPending;
+        private bool txRequested;
         private bool started;
 
         public VoxRadio(
             string name, string desc, bool rxOnly,
             IPAddress listenAddress, int listenPort,
             VoxConfig voxConfig,
-            Action<short[]> txAudioCallback, int txAudioSampleRate, Action<AudioFormat> rtcFormatCallback,
+            Action<short[]> txAudioCallback, Action<short[]> txAudioOutputCallback, int txAudioSampleRate, Action<AudioFormat> rtcFormatCallback,
             List<SoftkeyName> softkeys,
             List<TextLookup> zoneLookups = null, List<TextLookup> chanLookups = null
             ) : base(name, desc, rxOnly, listenAddress, listenPort, softkeys, zoneLookups, chanLookups, txAudioCallback, txAudioSampleRate, rtcFormatCallback)
@@ -77,6 +79,7 @@ namespace daemon
             txDisabled = rxOnly;
             RxOnly = rxOnly;
             startupDelayMs = Math.Max(0, this.voxConfig.StartupDelayMs);
+            this.txAudioOutputCallback = txAudioOutputCallback;
 
             rxGate = new VoxGate(
                 this.voxConfig.RxThresholdDb,
@@ -107,6 +110,7 @@ namespace daemon
             lock (stateLock)
             {
                 started = true;
+                txRequested = false;
                 rxGate.Reset();
                 txGate.Reset();
                 Status.ZoneName = voxConfig.ZoneName;
@@ -161,6 +165,7 @@ namespace daemon
             lock (stateLock)
             {
                 started = false;
+                txRequested = false;
                 Status.State = RadioState.Disconnected;
             }
 
@@ -174,6 +179,31 @@ namespace daemon
             {
                 Log.Warning("Ignoring VOX transmit request because this radio is RX-only");
                 return false;
+            }
+
+            RadioState nextState = RadioState.Idle;
+            bool statusChanged = false;
+
+            lock (stateLock)
+            {
+                txRequested = tx;
+
+                if (!tx)
+                {
+                    txGate.Reset();
+                }
+
+                nextState = GetVoxState();
+                if (Status.State != nextState)
+                {
+                    Status.State = nextState;
+                    statusChanged = true;
+                }
+            }
+
+            if (statusChanged)
+            {
+                RadioStatusCallback();
             }
 
             Log.Debug("Acknowledging VOX transmit {state}; radio state will follow TX audio level", tx ? "start" : "stop");
@@ -205,12 +235,20 @@ namespace daemon
 
         public void HandleTxAudioSamples(short[] samples)
         {
-            if (txDisabled)
+            bool shouldForward;
+
+            lock (stateLock)
+            {
+                shouldForward = started && txRequested && !txDisabled;
+            }
+
+            if (!shouldForward)
             {
                 return;
             }
 
             ProcessSamples(txGate, samples, "TX");
+            txAudioOutputCallback?.Invoke(samples);
         }
 
         public void HandleRxEncodedSamples(uint durationRtpUnits, byte[] encodedSamples)
@@ -252,9 +290,10 @@ namespace daemon
                 if (nowMs < ignoreAudioUntilMs)
                 {
                     gate.Calibrate(levelDb);
-                    if (Status.State != RadioState.Idle)
+                    nextState = GetVoxState();
+                    if (Status.State != nextState)
                     {
-                        Status.State = RadioState.Idle;
+                        Status.State = nextState;
                         statusChanged = true;
                     }
                 }
@@ -310,13 +349,12 @@ namespace daemon
 
                 if (nowMs < ignoreAudioUntilMs)
                 {
-                    if (Status.State != RadioState.Idle)
+                    nextState = GetVoxState();
+                    if (Status.State != nextState)
                     {
-                        Status.State = RadioState.Idle;
+                        Status.State = nextState;
                         statusChanged = true;
                     }
-
-                    nextState = RadioState.Idle;
                 }
                 else
                 {
@@ -342,6 +380,11 @@ namespace daemon
 
         private RadioState GetVoxState()
         {
+            if (!txDisabled && txRequested)
+            {
+                return RadioState.Transmitting;
+            }
+
             if (!txDisabled && txGate.Active)
             {
                 return RadioState.Transmitting;

--- a/daemon/Radio.VOX.cs
+++ b/daemon/Radio.VOX.cs
@@ -1,0 +1,510 @@
+using rc2_core;
+using Serilog;
+using SIPSorceryMedia.Abstractions;
+using System.Net;
+
+namespace daemon
+{
+    /// <summary>
+    /// Config object used to parse YML config for VOX control.
+    /// </summary>
+    public class VoxConfig
+    {
+        /// <summary>
+        /// Static zone name shown in the console for VOX radios.
+        /// </summary>
+        public string ZoneName = "VOX";
+        /// <summary>
+        /// Static channel name shown in the console for VOX radios.
+        /// </summary>
+        public string ChannelName = "Audio";
+        /// <summary>
+        /// RX audio level, in dBFS, required to mark the radio receiving.
+        /// </summary>
+        public double RxThresholdDb = -45.0;
+        /// <summary>
+        /// TX audio level, in dBFS, required to mark the radio transmitting.
+        /// </summary>
+        public double TxThresholdDb = -45.0;
+        /// <summary>
+        /// Audio must remain above threshold for this many milliseconds before the gate opens.
+        /// </summary>
+        public int AttackMs = 80;
+        /// <summary>
+        /// The gate remains open this many milliseconds after audio drops below threshold.
+        /// </summary>
+        public int HangMs = 800;
+        /// <summary>
+        /// Audio samples are ignored for this many milliseconds after startup to let devices settle.
+        /// </summary>
+        public int StartupDelayMs = 1000;
+        /// <summary>
+        /// VOX opens only when audio is this many dB above the learned noise floor.
+        /// </summary>
+        public double NoiseMarginDb = 8.0;
+        /// <summary>
+        /// After startup or reconnect, require one quiet sample before the gate can open.
+        /// </summary>
+        public bool RequireQuietAfterReset = true;
+    }
+
+    /// <summary>
+    /// Radio implementation for audio-only installations where TX/RX state is inferred from audio levels.
+    /// </summary>
+    internal sealed class VoxRadio : rc2_core.Radio
+    {
+        private readonly object stateLock = new object();
+        private readonly VoxConfig voxConfig;
+        private readonly VoxGate rxGate;
+        private readonly VoxGate txGate;
+        private readonly bool txDisabled;
+        private readonly System.Timers.Timer hangTimer;
+        private readonly int startupDelayMs;
+        private long ignoreAudioUntilMs;
+        private bool calibrationPending;
+        private bool started;
+
+        public VoxRadio(
+            string name, string desc, bool rxOnly,
+            IPAddress listenAddress, int listenPort,
+            VoxConfig voxConfig,
+            Action<short[]> txAudioCallback, int txAudioSampleRate, Action<AudioFormat> rtcFormatCallback,
+            List<SoftkeyName> softkeys,
+            List<TextLookup> zoneLookups = null, List<TextLookup> chanLookups = null
+            ) : base(name, desc, rxOnly, listenAddress, listenPort, softkeys, zoneLookups, chanLookups, txAudioCallback, txAudioSampleRate, rtcFormatCallback)
+        {
+            this.voxConfig = voxConfig ?? new VoxConfig();
+            txDisabled = rxOnly;
+            RxOnly = rxOnly;
+            startupDelayMs = Math.Max(0, this.voxConfig.StartupDelayMs);
+
+            rxGate = new VoxGate(
+                this.voxConfig.RxThresholdDb,
+                this.voxConfig.NoiseMarginDb,
+                this.voxConfig.RequireQuietAfterReset,
+                Math.Max(0, this.voxConfig.AttackMs),
+                Math.Max(1, this.voxConfig.HangMs));
+            txGate = new VoxGate(
+                this.voxConfig.TxThresholdDb,
+                this.voxConfig.NoiseMarginDb,
+                this.voxConfig.RequireQuietAfterReset,
+                Math.Max(0, this.voxConfig.AttackMs),
+                Math.Max(1, this.voxConfig.HangMs));
+
+            Status.ZoneName = this.voxConfig.ZoneName;
+            Status.ChannelName = this.voxConfig.ChannelName;
+
+            hangTimer = new System.Timers.Timer(Math.Clamp(this.voxConfig.HangMs / 4, 50, 250));
+            hangTimer.AutoReset = true;
+            hangTimer.Elapsed += (sender, args) => ExpireGates();
+        }
+
+        public override void Start(bool reset = false)
+        {
+            Log.Information("Starting new VOX radio instance");
+            base.Start(reset);
+
+            lock (stateLock)
+            {
+                started = true;
+                rxGate.Reset();
+                txGate.Reset();
+                Status.ZoneName = voxConfig.ZoneName;
+                Status.ChannelName = voxConfig.ChannelName;
+                Status.State = RadioState.Idle;
+                ArmWarmup(Environment.TickCount64);
+            }
+
+            if (startupDelayMs > 0)
+            {
+                Log.Debug("VOX startup delay active for {delay} ms", startupDelayMs);
+            }
+
+            hangTimer.Start();
+            RadioStatusCallback();
+        }
+
+        public void ReArmStartupDelay(string reason)
+        {
+            bool statusChanged = false;
+
+            lock (stateLock)
+            {
+                ArmWarmup(Environment.TickCount64);
+
+                if (started && Status.State != RadioState.Idle)
+                {
+                    Status.State = RadioState.Idle;
+                    statusChanged = true;
+                }
+            }
+
+            if (startupDelayMs > 0)
+            {
+                Log.Debug("VOX startup delay re-armed for {delay} ms ({reason})", startupDelayMs, reason);
+            }
+            else
+            {
+                Log.Debug("VOX gates reset ({reason})", reason);
+            }
+
+            if (statusChanged)
+            {
+                RadioStatusCallback();
+            }
+        }
+
+        public override void Stop()
+        {
+            hangTimer.Stop();
+
+            lock (stateLock)
+            {
+                started = false;
+                Status.State = RadioState.Disconnected;
+            }
+
+            RadioStatusCallback();
+            base.Stop();
+        }
+
+        public override bool SetTransmit(bool tx)
+        {
+            if (tx && txDisabled)
+            {
+                Log.Warning("Ignoring VOX transmit request because this radio is RX-only");
+                return false;
+            }
+
+            Log.Debug("Acknowledging VOX transmit {state}; radio state will follow TX audio level", tx ? "start" : "stop");
+            return true;
+        }
+
+        public override bool ChangeChannel(bool down)
+        {
+            Log.Debug("Ignoring channel change request because VOX control has no channel interface");
+            return false;
+        }
+
+        public override bool PressButton(SoftkeyName name)
+        {
+            Log.Debug("Ignoring button press {name} because VOX control has no button interface", name);
+            return false;
+        }
+
+        public override bool ReleaseButton(SoftkeyName name)
+        {
+            Log.Debug("Ignoring button release {name} because VOX control has no button interface", name);
+            return false;
+        }
+
+        public void HandleRxAudioSamples(AudioSamplingRatesEnum samplingRate, uint durationMilliseconds, short[] samples)
+        {
+            ProcessSamples(rxGate, samples, "RX");
+        }
+
+        public void HandleTxAudioSamples(short[] samples)
+        {
+            if (txDisabled)
+            {
+                return;
+            }
+
+            ProcessSamples(txGate, samples, "TX");
+        }
+
+        public void HandleRxEncodedSamples(uint durationRtpUnits, byte[] encodedSamples)
+        {
+            bool shouldForward;
+
+            lock (stateLock)
+            {
+                shouldForward = started && Status.State == RadioState.Receiving;
+            }
+
+            if (!shouldForward)
+            {
+                return;
+            }
+
+            RxSendEncodedSamples(durationRtpUnits, encodedSamples);
+        }
+
+        private void ProcessSamples(VoxGate gate, short[] samples, string direction)
+        {
+            if (samples == null || samples.Length == 0)
+            {
+                return;
+            }
+
+            long nowMs = Environment.TickCount64;
+            double levelDb = CalculateRmsDb(samples);
+            RadioState nextState = RadioState.Idle;
+            bool statusChanged = false;
+
+            lock (stateLock)
+            {
+                if (!started)
+                {
+                    return;
+                }
+
+                if (nowMs < ignoreAudioUntilMs)
+                {
+                    gate.Calibrate(levelDb);
+                    if (Status.State != RadioState.Idle)
+                    {
+                        Status.State = RadioState.Idle;
+                        statusChanged = true;
+                    }
+                }
+            }
+
+            if (nowMs < ignoreAudioUntilMs)
+            {
+                if (statusChanged)
+                {
+                    RadioStatusCallback();
+                }
+
+                return;
+            }
+
+            lock (stateLock)
+            {
+                if (!started)
+                {
+                    return;
+                }
+
+                CompleteWarmup();
+                gate.Process(levelDb, nowMs);
+                nextState = GetVoxState();
+                if (Status.State != nextState)
+                {
+                    Status.State = nextState;
+                    statusChanged = true;
+                }
+            }
+
+            if (statusChanged)
+            {
+                Log.Debug("VOX {direction} level {level:0.0} dBFS changed radio state to {state}", direction, levelDb, nextState);
+                RadioStatusCallback();
+            }
+        }
+
+        private void ExpireGates()
+        {
+            RadioState nextState = RadioState.Idle;
+            bool statusChanged = false;
+
+            lock (stateLock)
+            {
+                if (!started)
+                {
+                    return;
+                }
+
+                long nowMs = Environment.TickCount64;
+
+                if (nowMs < ignoreAudioUntilMs)
+                {
+                    if (Status.State != RadioState.Idle)
+                    {
+                        Status.State = RadioState.Idle;
+                        statusChanged = true;
+                    }
+
+                    nextState = RadioState.Idle;
+                }
+                else
+                {
+                    CompleteWarmup();
+                    rxGate.Expire(nowMs);
+                    txGate.Expire(nowMs);
+
+                    nextState = GetVoxState();
+                    if (Status.State != nextState)
+                    {
+                        Status.State = nextState;
+                        statusChanged = true;
+                    }
+                }
+            }
+
+            if (statusChanged)
+            {
+                Log.Debug("VOX hang timer changed radio state to {state}", nextState);
+                RadioStatusCallback();
+            }
+        }
+
+        private RadioState GetVoxState()
+        {
+            if (!txDisabled && txGate.Active)
+            {
+                return RadioState.Transmitting;
+            }
+
+            if (rxGate.Active)
+            {
+                return RadioState.Receiving;
+            }
+
+            return RadioState.Idle;
+        }
+
+        private void ArmWarmup(long nowMs)
+        {
+            rxGate.Reset();
+            txGate.Reset();
+            ignoreAudioUntilMs = nowMs + startupDelayMs;
+            calibrationPending = true;
+        }
+
+        private void CompleteWarmup()
+        {
+            if (!calibrationPending)
+            {
+                return;
+            }
+
+            calibrationPending = false;
+            rxGate.CompleteCalibration();
+            txGate.CompleteCalibration();
+            Log.Debug(
+                "VOX calibration complete: RX floor {rxFloor:0.0} dBFS, RX effective threshold {rxThreshold:0.0} dBFS; TX floor {txFloor:0.0} dBFS, TX effective threshold {txThreshold:0.0} dBFS",
+                rxGate.NoiseFloorDb,
+                rxGate.EffectiveThresholdDb,
+                txGate.NoiseFloorDb,
+                txGate.EffectiveThresholdDb);
+        }
+
+        private static double CalculateRmsDb(short[] samples)
+        {
+            double sumSquares = 0.0;
+
+            foreach (short sample in samples)
+            {
+                double normalized = sample / 32768.0;
+                sumSquares += normalized * normalized;
+            }
+
+            double rms = Math.Sqrt(sumSquares / samples.Length);
+            if (rms <= 0.0)
+            {
+                return double.NegativeInfinity;
+            }
+
+            return 20.0 * Math.Log10(rms);
+        }
+
+        private sealed class VoxGate
+        {
+            private readonly double thresholdDb;
+            private readonly double noiseMarginDb;
+            private readonly bool requireQuietAfterReset;
+            private readonly int attackMs;
+            private readonly int hangMs;
+            private long? aboveThresholdSinceMs;
+            private long lastAboveThresholdMs = long.MinValue;
+            private double calibrationSumDb;
+            private int calibrationCount;
+            private bool waitingForQuiet;
+
+            public bool Active { get; private set; }
+            public double NoiseFloorDb { get; private set; } = double.NegativeInfinity;
+            public double EffectiveThresholdDb
+            {
+                get
+                {
+                    if (double.IsNegativeInfinity(NoiseFloorDb))
+                    {
+                        return thresholdDb;
+                    }
+
+                    return Math.Max(thresholdDb, NoiseFloorDb + noiseMarginDb);
+                }
+            }
+
+            public VoxGate(double thresholdDb, double noiseMarginDb, bool requireQuietAfterReset, int attackMs, int hangMs)
+            {
+                this.thresholdDb = thresholdDb;
+                this.noiseMarginDb = noiseMarginDb;
+                this.requireQuietAfterReset = requireQuietAfterReset;
+                this.attackMs = attackMs;
+                this.hangMs = hangMs;
+            }
+
+            public void Calibrate(double levelDb)
+            {
+                if (double.IsNegativeInfinity(levelDb) || double.IsNaN(levelDb))
+                {
+                    return;
+                }
+
+                calibrationSumDb += levelDb;
+                calibrationCount++;
+            }
+
+            public void CompleteCalibration()
+            {
+                if (calibrationCount > 0)
+                {
+                    NoiseFloorDb = calibrationSumDb / calibrationCount;
+                }
+            }
+
+            public void Process(double levelDb, long nowMs)
+            {
+                double effectiveThresholdDb = EffectiveThresholdDb;
+
+                if (waitingForQuiet)
+                {
+                    if (levelDb < effectiveThresholdDb)
+                    {
+                        waitingForQuiet = false;
+                    }
+
+                    return;
+                }
+
+                if (levelDb >= effectiveThresholdDb)
+                {
+                    lastAboveThresholdMs = nowMs;
+                    aboveThresholdSinceMs ??= nowMs;
+
+                    if (!Active && nowMs - aboveThresholdSinceMs.Value >= attackMs)
+                    {
+                        Active = true;
+                    }
+
+                    return;
+                }
+
+                aboveThresholdSinceMs = null;
+                Expire(nowMs);
+            }
+
+            public void Expire(long nowMs)
+            {
+                if (Active && lastAboveThresholdMs != long.MinValue && nowMs - lastAboveThresholdMs >= hangMs)
+                {
+                    Active = false;
+                    aboveThresholdSinceMs = null;
+                }
+            }
+
+            public void Reset()
+            {
+                Active = false;
+                aboveThresholdSinceMs = null;
+                lastAboveThresholdMs = long.MinValue;
+                calibrationSumDb = 0.0;
+                calibrationCount = 0;
+                waitingForQuiet = requireQuietAfterReset;
+            }
+        }
+    }
+}

--- a/daemon/Radio.VOX.cs
+++ b/daemon/Radio.VOX.cs
@@ -50,6 +50,9 @@ namespace daemon
 
     /// <summary>
     /// Radio implementation for audio-only installations where TX/RX state is inferred from audio levels.
+    /// VOX mode uses the normal RC2 WebRTC server for console connections, but it replaces
+    /// hardware control-line state with two audio gates: one for local RX audio and one for
+    /// console TX audio.
     /// </summary>
     internal sealed class VoxRadio : rc2_core.Radio
     {
@@ -61,6 +64,8 @@ namespace daemon
         private readonly System.Timers.Timer hangTimer;
         private readonly int startupDelayMs;
         private readonly Action<short[]> txAudioOutputCallback;
+        // Startup/reconnect noise can briefly spike when SDL or WebRTC audio devices open.
+        // During this window the gates learn the idle floor instead of changing radio state.
         private long ignoreAudioUntilMs;
         private bool calibrationPending;
         private bool txRequested;
@@ -68,12 +73,12 @@ namespace daemon
 
         public VoxRadio(
             string name, string desc, bool rxOnly,
-            IPAddress listenAddress, int listenPort,
+            IPAddress listenAddress, int listenPort, List<IPNetwork> allowedNetworks,
             VoxConfig voxConfig,
             Action<short[]> txAudioCallback, Action<short[]> txAudioOutputCallback, int txAudioSampleRate, Action<AudioFormat> rtcFormatCallback,
             List<SoftkeyName> softkeys,
             List<TextLookup> zoneLookups = null, List<TextLookup> chanLookups = null
-            ) : base(name, desc, rxOnly, listenAddress, listenPort, softkeys, zoneLookups, chanLookups, txAudioCallback, txAudioSampleRate, rtcFormatCallback)
+            ) : base(name, desc, rxOnly, listenAddress, listenPort, allowedNetworks, softkeys, zoneLookups, chanLookups, txAudioCallback, txAudioSampleRate, rtcFormatCallback)
         {
             this.voxConfig = voxConfig ?? new VoxConfig();
             txDisabled = rxOnly;
@@ -97,6 +102,8 @@ namespace daemon
             Status.ZoneName = this.voxConfig.ZoneName;
             Status.ChannelName = this.voxConfig.ChannelName;
 
+            // The timer enforces hang time even when no more audio buffers arrive after
+            // the signal falls below threshold.
             hangTimer = new System.Timers.Timer(Math.Clamp(this.voxConfig.HangMs / 4, 50, 250));
             hangTimer.AutoReset = true;
             hangTimer.Elapsed += (sender, args) => ExpireGates();
@@ -130,6 +137,8 @@ namespace daemon
 
         public void ReArmStartupDelay(string reason)
         {
+            // WebRTC format negotiation can restart local audio devices. Re-arm warmup so
+            // device-open noise does not immediately trip RX or TX.
             bool statusChanged = false;
 
             lock (stateLock)
@@ -186,6 +195,8 @@ namespace daemon
 
             lock (stateLock)
             {
+                // PTT is acknowledged immediately, but actual TX audio is still gated so
+                // silence from the console does not hold the radio in Transmitting forever.
                 txRequested = tx;
 
                 if (!tx)
@@ -230,11 +241,14 @@ namespace daemon
 
         public void HandleRxAudioSamples(AudioSamplingRatesEnum samplingRate, uint durationMilliseconds, short[] samples)
         {
+            // Local microphone/radio RX samples drive the receive gate.
             ProcessSamples(rxGate, samples, "RX");
         }
 
         public void HandleTxAudioSamples(short[] samples)
         {
+            // Console TX samples drive the transmit gate and are then forwarded to the
+            // local audio output only while a TX request is active.
             bool shouldForward;
 
             lock (stateLock)
@@ -253,6 +267,8 @@ namespace daemon
 
         public void HandleRxEncodedSamples(uint durationRtpUnits, byte[] encodedSamples)
         {
+            // Encoded RX audio is sent to WebRTC peers only while the RX gate says the
+            // radio is actually receiving.
             bool shouldForward;
 
             lock (stateLock)
@@ -280,6 +296,8 @@ namespace daemon
             RadioState nextState = RadioState.Idle;
             bool statusChanged = false;
 
+            // During warmup the sample level is used only for noise-floor calibration.
+            // Once warmup completes, the same gate applies threshold, attack, and hang.
             lock (stateLock)
             {
                 if (!started)
@@ -380,6 +398,8 @@ namespace daemon
 
         private RadioState GetVoxState()
         {
+            // Prefer TX over RX so a console transmit request wins if both gates are
+            // active at the same time.
             if (!txDisabled && txRequested)
             {
                 return RadioState.Transmitting;
@@ -426,6 +446,7 @@ namespace daemon
 
         private static double CalculateRmsDb(short[] samples)
         {
+            // Convert PCM16 audio to dBFS so thresholds are independent of buffer length.
             double sumSquares = 0.0;
 
             foreach (short sample in samples)
@@ -445,6 +466,8 @@ namespace daemon
 
         private sealed class VoxGate
         {
+            // VoxGate tracks one direction of audio. It combines a static dBFS threshold
+            // with an optional learned noise floor, attack time, and hang time.
             private readonly double thresholdDb;
             private readonly double noiseMarginDb;
             private readonly bool requireQuietAfterReset;
@@ -503,6 +526,8 @@ namespace daemon
             {
                 double effectiveThresholdDb = EffectiveThresholdDb;
 
+                // After a reset, require a below-threshold sample before allowing the gate
+                // to open. This prevents already-hot audio from immediately retriggering.
                 if (waitingForQuiet)
                 {
                     if (levelDb < effectiveThresholdDb)

--- a/daemon/config.example.yml
+++ b/daemon/config.example.yml
@@ -17,7 +17,7 @@ daemon:
 control:
     # Control Mode
     #
-    #   0 - VOX (control of TX/RX states is based on audio levels only) [Not Yet Implemented]
+    #   0 - VOX (control of TX/RX states is based on audio levels only)
     #   1 - TRC (Tone remote control based on EIA tone signalling) [Not Yet Implemented]
     #   2 - SB9600 (emulation of Motorola Astro W-series and MCS2000 model-3 control heads over SB9600)
     #   3 - XCMP Serial (control of Motorola XTL radios via serial)
@@ -26,6 +26,27 @@ control:
 
     # RX Only (TX disabled)
     rxOnly: false
+
+    # VOX configuration
+    vox:
+        # Static zone/channel labels shown by the console
+        zoneName: "VOX"
+        channelName: "Audio"
+        # Audio level in dBFS required to mark RX/TX active.
+        # Less negative is less sensitive; more negative is more sensitive.
+        rxThresholdDb: -45
+        txThresholdDb: -45
+        # Audio must stay above threshold for attackMs before opening,
+        # and stays open for hangMs after dropping below threshold.
+        attackMs: 80
+        hangMs: 800
+        # Ignore audio briefly after startup so USB device-open noise does not trip VOX.
+        startupDelayMs: 1000
+        # During startup/reconnect, learn the idle noise floor and require audio
+        # to exceed it by this margin before opening VOX.
+        noiseMarginDb: 8
+        # After startup/reconnect, require quiet before the next VOX open.
+        requireQuietAfterReset: true
 
     # SB9600 configuration
     sb9600:


### PR DESCRIPTION
## Summary

This PR implements the daemon VOX control mode and makes it usable for audio-only radio setups such as an FT-991A running DATA VOX through a USB audio interface.

VOX can now drive radio RX/TX state from audio levels, forward receive audio only when active, and pass transmit audio to the configured TX audio device only when that specific radio has been keyed.

## What Changed

- Added `VoxRadio` implementation for `controlMode: 0`
- Added configurable VOX settings:
  - RX/TX thresholds
  - attack and hang timing
  - startup delay
  - noise-floor margin
  - quiet-after-reset behavior
  - static zone/channel labels
- Added raw RX audio monitoring so VOX state can be driven from local audio input
- Gated RX audio forwarding so idle/reconnect noise does not open the radio stream
- Started local audio early for VOX so RX detection works before WebRTC negotiation completes
- Routed WebRTC TX audio through VOX before sending it to the local TX audio device
- Prevented shared console mic audio from accidentally keying the VOX radio when other radios are selected
- Allowed console alert tones to key and pass through the VOX radio correctly
- Updated example configuration for VOX
- Updated the `rc2-core` submodule for reliable initial WebRTC audio negotiation

## Why

This enables radios that can self-key from audio, such as an FT-991A in DATA VOX mode, to work without CAT/PTT control. 
