### PR TITLE
Add SDRTrunk direct Icecast stream support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 release/
 
 .vscode/
+
+daemon/generated-sdrtrunk/
+daemon/logs/

--- a/daemon/Configuration.cs
+++ b/daemon/Configuration.cs
@@ -66,7 +66,9 @@ namespace daemon
         /// </summary>
         public MotoSb9600Config Sb9600 = new MotoSb9600Config();
         /// <summary>
-        /// Config for direct sdrtrunk audio stream ingest
+        /// Config for direct sdrtrunk audio stream ingest. This is separate from the
+        /// daemon listen address because the console connects to the daemon while
+        /// sdrtrunk connects to the source listener.
         /// </summary>
         public SdrTrunkConfig SdrTrunk = new SdrTrunkConfig();
     }

--- a/daemon/Configuration.cs
+++ b/daemon/Configuration.cs
@@ -44,7 +44,8 @@ namespace daemon
         TRC = 1,
         SB9600 = 2,
         XCMP_SER = 3,
-        XCMP_USB = 4
+        XCMP_USB = 4,
+        SDRTrunk = 5
     }
 
     /// <summary>
@@ -64,6 +65,10 @@ namespace daemon
         /// Config for motorola SB9600
         /// </summary>
         public MotoSb9600Config Sb9600 = new MotoSb9600Config();
+        /// <summary>
+        /// Config for direct sdrtrunk audio stream ingest
+        /// </summary>
+        public SdrTrunkConfig SdrTrunk = new SdrTrunkConfig();
     }
 
     /// <summary>

--- a/daemon/IcecastSourceServer.cs
+++ b/daemon/IcecastSourceServer.cs
@@ -1,0 +1,369 @@
+using Serilog;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+
+namespace daemon
+{
+    internal sealed class IcecastSourceRequest
+    {
+        public string Method { get; init; } = "";
+        public string Mount { get; init; } = "";
+        public string Protocol { get; init; } = "";
+        public Dictionary<string, string> Headers { get; init; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        public Stream Body { get; init; } = Stream.Null;
+        public IPEndPoint RemoteEndPoint { get; init; }
+    }
+
+    internal sealed class IcecastSourceServer
+    {
+        private readonly IPAddress listenAddress;
+        private readonly int listenPort;
+        private readonly string mount;
+        private readonly string sourcePassword;
+        private readonly Func<IcecastSourceRequest, CancellationToken, Task> sourceHandler;
+        private readonly Action<IcecastSourceRequest> metadataHandler;
+        private readonly object clientLock = new object();
+        private TcpListener listener;
+        private TcpClient activeClient;
+        private CancellationTokenSource stopCts;
+        private Task acceptTask;
+
+        public IcecastSourceServer(
+            IPAddress listenAddress,
+            int listenPort,
+            string mount,
+            string sourcePassword,
+            Func<IcecastSourceRequest, CancellationToken, Task> sourceHandler,
+            Action<IcecastSourceRequest> metadataHandler = null)
+        {
+            this.listenAddress = listenAddress;
+            this.listenPort = listenPort;
+            this.mount = NormalizeMount(mount);
+            this.sourcePassword = sourcePassword ?? "";
+            this.sourceHandler = sourceHandler;
+            this.metadataHandler = metadataHandler;
+        }
+
+        public void Start()
+        {
+            stopCts = new CancellationTokenSource();
+            listener = new TcpListener(listenAddress, listenPort);
+            listener.Start();
+            acceptTask = Task.Run(() => AcceptLoop(stopCts.Token));
+            Log.Information("Starting sdrtrunk Icecast source listener on {address}:{port}{mount}", listenAddress, listenPort, mount);
+        }
+
+        public async Task Stop()
+        {
+            stopCts?.Cancel();
+
+            lock (clientLock)
+            {
+                activeClient?.Close();
+                activeClient = null;
+            }
+
+            listener?.Stop();
+
+            if (acceptTask != null)
+            {
+                try
+                {
+                    await acceptTask;
+                }
+                catch (OperationCanceledException)
+                {
+                }
+                catch (ObjectDisposedException)
+                {
+                }
+            }
+        }
+
+        public void CloseActiveSource(string reason)
+        {
+            TcpClient client = null;
+
+            lock (clientLock)
+            {
+                client = activeClient;
+                activeClient = null;
+            }
+
+            if (client == null)
+            {
+                return;
+            }
+
+            Log.Warning("Closing active sdrtrunk source connection: {reason}", reason);
+            client.Close();
+        }
+
+        private async Task AcceptLoop(CancellationToken token)
+        {
+            while (!token.IsCancellationRequested)
+            {
+                TcpClient client;
+
+                try
+                {
+                    client = await listener.AcceptTcpClientAsync(token);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                catch (ObjectDisposedException)
+                {
+                    break;
+                }
+
+                _ = Task.Run(() => HandleClient(client, token), token);
+            }
+        }
+
+        private async Task HandleClient(TcpClient client, CancellationToken token)
+        {
+            IPEndPoint remoteEndPoint = client.Client.RemoteEndPoint as IPEndPoint;
+            Log.Information("sdrtrunk source connection opened from {remote}", remoteEndPoint);
+
+            try
+            {
+                using (client)
+                using (NetworkStream stream = client.GetStream())
+                {
+                    IcecastSourceRequest request = await ReadRequest(stream, remoteEndPoint, token);
+                    Log.Debug(
+                        "sdrtrunk source request {method} {mount} {protocol} from {remote}",
+                        request.Method,
+                        request.Mount,
+                        request.Protocol,
+                        remoteEndPoint);
+
+                    if (IsMetadataRequest(request))
+                    {
+                        Log.Debug("Accepting sdrtrunk metadata update {mount}", request.Mount);
+                        metadataHandler?.Invoke(request);
+                        await WriteResponse(stream, request, "200 OK", token);
+                        return;
+                    }
+
+                    if (!IsSupportedSourceMethod(request.Method))
+                    {
+                        await WriteResponse(stream, request, "405 Method Not Allowed", token);
+                        return;
+                    }
+
+                    if (!string.Equals(NormalizeMount(request.Mount), mount, StringComparison.OrdinalIgnoreCase))
+                    {
+                        Log.Warning("Rejecting sdrtrunk source for mount {requestMount}; expected {mount}", request.Mount, mount);
+                        await WriteResponse(stream, request, "404 Not Found", token);
+                        return;
+                    }
+
+                    if (!IsAuthorized(request.Headers))
+                    {
+                        Log.Warning("Rejecting unauthorized sdrtrunk source connection from {remote}", remoteEndPoint);
+                        await WriteResponse(stream, request, "401 Unauthorized", token, "WWW-Authenticate: Basic realm=\"RC2 SDRTrunk\"\r\n");
+                        return;
+                    }
+
+                    TcpClient previousClient = null;
+                    lock (clientLock)
+                    {
+                        previousClient = activeClient;
+                        activeClient = client;
+                    }
+
+                    if (previousClient != null)
+                    {
+                        Log.Warning("Replacing existing sdrtrunk source connection");
+                        previousClient.Close();
+                    }
+
+                    if (request.Headers.TryGetValue("expect", out string expect) && expect.Contains("100-continue", StringComparison.OrdinalIgnoreCase))
+                    {
+                        byte[] continueBytes = Encoding.ASCII.GetBytes("HTTP/1.1 100 Continue\r\n\r\n");
+                        await stream.WriteAsync(continueBytes, token);
+                    }
+
+                    await WriteResponse(stream, request, "200 OK", token);
+                    await sourceHandler(request, token);
+                }
+            }
+            catch (EndOfStreamException)
+            {
+                Log.Warning("sdrtrunk source connection closed before request completed");
+            }
+            catch (IOException ex)
+            {
+                Log.Warning("sdrtrunk source connection closed: {message}", ex.Message);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "sdrtrunk source connection failed");
+            }
+            finally
+            {
+                lock (clientLock)
+                {
+                    if (ReferenceEquals(activeClient, client))
+                    {
+                        activeClient = null;
+                    }
+                }
+
+                Log.Information("sdrtrunk source connection closed from {remote}", remoteEndPoint);
+            }
+        }
+
+        private async Task<IcecastSourceRequest> ReadRequest(NetworkStream stream, IPEndPoint remoteEndPoint, CancellationToken token)
+        {
+            string requestLine = await ReadLine(stream, token);
+            string[] requestParts = requestLine.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+            if (requestParts.Length < 2)
+            {
+                throw new InvalidDataException($"Invalid source request line: {requestLine}");
+            }
+
+            Dictionary<string, string> headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            while (true)
+            {
+                string line = await ReadLine(stream, token);
+                if (line.Length == 0)
+                {
+                    break;
+                }
+
+                int separator = line.IndexOf(':');
+                if (separator <= 0)
+                {
+                    continue;
+                }
+
+                string key = line.Substring(0, separator).Trim();
+                string value = line.Substring(separator + 1).Trim();
+                headers[key] = value;
+            }
+
+            return new IcecastSourceRequest
+            {
+                Method = requestParts[0],
+                Mount = requestParts[1],
+                Protocol = requestParts.Length >= 3 ? requestParts[2] : "",
+                Headers = headers,
+                Body = stream,
+                RemoteEndPoint = remoteEndPoint
+            };
+        }
+
+        private static async Task<string> ReadLine(NetworkStream stream, CancellationToken token)
+        {
+            List<byte> bytes = new List<byte>();
+
+            while (true)
+            {
+                byte[] buffer = new byte[1];
+                int read = await stream.ReadAsync(buffer, token);
+
+                if (read == 0)
+                {
+                    throw new EndOfStreamException();
+                }
+
+                if (buffer[0] == '\n')
+                {
+                    break;
+                }
+
+                if (buffer[0] != '\r')
+                {
+                    bytes.Add(buffer[0]);
+                }
+            }
+
+            return Encoding.ASCII.GetString(bytes.ToArray());
+        }
+
+        private bool IsAuthorized(Dictionary<string, string> headers)
+        {
+            if (string.IsNullOrEmpty(sourcePassword))
+            {
+                return true;
+            }
+
+            if (headers.TryGetValue("authorization", out string authorization) &&
+                authorization.StartsWith("Basic ", StringComparison.OrdinalIgnoreCase))
+            {
+                string encoded = authorization.Substring("Basic ".Length).Trim();
+                string decoded = Encoding.UTF8.GetString(Convert.FromBase64String(encoded));
+                int separator = decoded.IndexOf(':');
+
+                if (separator >= 0 && decoded.Substring(separator + 1) == sourcePassword)
+                {
+                    return true;
+                }
+            }
+
+            if (headers.TryGetValue("ice-password", out string icePassword) && icePassword == sourcePassword)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool IsSupportedSourceMethod(string method)
+        {
+            return method.Equals("SOURCE", StringComparison.OrdinalIgnoreCase) ||
+                method.Equals("PUT", StringComparison.OrdinalIgnoreCase) ||
+                method.Equals("POST", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsMetadataRequest(IcecastSourceRequest request)
+        {
+            return request.Method.Equals("GET", StringComparison.OrdinalIgnoreCase) &&
+                request.Mount.StartsWith("/admin/metadata", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static async Task WriteResponse(NetworkStream stream, IcecastSourceRequest request, string status, CancellationToken token, string extraHeaders = "")
+        {
+            string response;
+
+            if (request.Method.Equals("SOURCE", StringComparison.OrdinalIgnoreCase))
+            {
+                response = $"HTTP/1.0 {status}\r\n{extraHeaders}\r\n";
+            }
+            else
+            {
+                response =
+                    $"HTTP/1.1 {status}\r\n" +
+                    "Server: Icecast 2.4.4\r\n" +
+                    "Connection: keep-alive\r\n" +
+                    "Content-Length: 0\r\n" +
+                    extraHeaders +
+                    "\r\n";
+            }
+
+            byte[] bytes = Encoding.ASCII.GetBytes(response);
+            await stream.WriteAsync(bytes, token);
+            await stream.FlushAsync(token);
+        }
+
+        private static string NormalizeMount(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return "/sdrtrunk";
+            }
+
+            return value.StartsWith("/") ? value : "/" + value;
+        }
+    }
+}

--- a/daemon/IcecastSourceServer.cs
+++ b/daemon/IcecastSourceServer.cs
@@ -5,6 +5,9 @@ using System.Text;
 
 namespace daemon
 {
+    /// <summary>
+    /// Parsed source or metadata request from the small Icecast-compatible listener.
+    /// </summary>
     internal sealed class IcecastSourceRequest
     {
         public string Method { get; init; } = "";
@@ -15,6 +18,11 @@ namespace daemon
         public IPEndPoint RemoteEndPoint { get; init; }
     }
 
+    /// <summary>
+    /// Minimal Icecast source listener used only for sdrtrunk ingest.
+    /// It accepts SOURCE/PUT/POST audio streams and the /admin/metadata updates
+    /// that sdrtrunk sends, then hands the accepted stream to SdrTrunkRadio.
+    /// </summary>
     internal sealed class IcecastSourceServer
     {
         private readonly IPAddress listenAddress;
@@ -24,6 +32,8 @@ namespace daemon
         private readonly Func<IcecastSourceRequest, CancellationToken, Task> sourceHandler;
         private readonly Action<IcecastSourceRequest> metadataHandler;
         private readonly object clientLock = new object();
+        // sdrtrunk should have exactly one active source stream for a mount; replacing
+        // the old client mirrors Icecast behavior and lets the source reconnect cleanly.
         private TcpListener listener;
         private TcpClient activeClient;
         private CancellationTokenSource stopCts;
@@ -102,6 +112,9 @@ namespace daemon
 
         private async Task AcceptLoop(CancellationToken token)
         {
+            // Keep accepting new TCP clients until Stop cancels the listener. Each client
+            // is handled on a background task so metadata updates do not block the source
+            // stream and a reconnect can replace the current source.
             while (!token.IsCancellationRequested)
             {
                 TcpClient client;
@@ -143,6 +156,8 @@ namespace daemon
 
                     if (IsMetadataRequest(request))
                     {
+                        // Metadata updates are short HTTP GETs to Icecast's admin path.
+                        // They update display labels but do not carry audio.
                         Log.Debug("Accepting sdrtrunk metadata update {mount}", request.Mount);
                         metadataHandler?.Invoke(request);
                         await WriteResponse(stream, request, "200 OK", token);
@@ -184,6 +199,8 @@ namespace daemon
 
                     if (request.Headers.TryGetValue("expect", out string expect) && expect.Contains("100-continue", StringComparison.OrdinalIgnoreCase))
                     {
+                        // Some source clients wait for this interim response before they
+                        // send the MP3 body, so acknowledge it before the final 200 OK.
                         byte[] continueBytes = Encoding.ASCII.GetBytes("HTTP/1.1 100 Continue\r\n\r\n");
                         await stream.WriteAsync(continueBytes, token);
                     }
@@ -267,6 +284,8 @@ namespace daemon
         {
             List<byte> bytes = new List<byte>();
 
+            // Icecast source headers are small ASCII lines. Reading byte-by-byte keeps
+            // this parser from consuming the first bytes of the MP3 stream body.
             while (true)
             {
                 byte[] buffer = new byte[1];
@@ -298,6 +317,8 @@ namespace daemon
                 return true;
             }
 
+            // sdrtrunk and Icecast-compatible clients may send either HTTP Basic auth or
+            // the older ice-password header, so accept both forms.
             if (headers.TryGetValue("authorization", out string authorization) &&
                 authorization.StartsWith("Basic ", StringComparison.OrdinalIgnoreCase))
             {
@@ -338,6 +359,7 @@ namespace daemon
 
             if (request.Method.Equals("SOURCE", StringComparison.OrdinalIgnoreCase))
             {
+                // Legacy SOURCE clients expect the terse HTTP/1.0-style Icecast response.
                 response = $"HTTP/1.0 {status}\r\n{extraHeaders}\r\n";
             }
             else

--- a/daemon/Program.cs
+++ b/daemon/Program.cs
@@ -195,6 +195,9 @@ namespace netcore_cli
                     .CreateLogger();
             }
 
+            // SDRTrunk mode gets RX audio from an incoming stream, so it skips SDL2
+            // local audio devices. Hardware-backed control modes still need SDL2 for
+            // microphone/speaker audio between the radio and WebRTC peers.
             if (Config.Control.ControlMode != RadioControlMode.SDRTrunk)
             {
                 // Setup Audio Devices
@@ -207,6 +210,9 @@ namespace netcore_cli
             {
                 case RadioControlMode.SDRTrunk:
                 {
+                    // This radio acts as an RX-only bridge: sdrtrunk connects to the
+                    // configured Icecast-compatible listener, and decoded stream audio is
+                    // forwarded through the normal RC2 WebRTC radio path.
                     radio = new SdrTrunkRadio(
                         Config.Daemon.Name,
                         Config.Daemon.Desc,
@@ -249,7 +255,8 @@ namespace netcore_cli
             // Setup RX audio callback
             if (Config.Control.ControlMode == RadioControlMode.SDRTrunk)
             {
-                // sdrtrunk mode receives audio from its own Icecast-compatible source listener.
+                // SdrTrunkRadio calls RxSendPCM16Samples itself after decoding MP3 frames,
+                // so there is no local encoded-audio callback to attach here.
             }
             else
             {

--- a/daemon/Program.cs
+++ b/daemon/Program.cs
@@ -218,6 +218,7 @@ namespace netcore_cli
                         Config.Daemon.Desc,
                         Config.Daemon.ListenAddress,
                         Config.Daemon.ListenPort,
+                        Config.Daemon.AllowedNetworks,
                         Config.Control.SdrTrunk,
                         Config.Softkeys,
                         Config.TextLookups.Zone,

--- a/daemon/Program.cs
+++ b/daemon/Program.cs
@@ -195,13 +195,30 @@ namespace netcore_cli
                     .CreateLogger();
             }
 
-            // Setup Audio Devices
-            Log.Logger.Debug("Configuring local audio");
-            localAudio = new LocalAudio(Config.Audio.RxDevice, Config.Audio.TxDevice, radio, Config.Control.RxOnly);
+            if (Config.Control.ControlMode != RadioControlMode.SDRTrunk)
+            {
+                // Setup Audio Devices
+                Log.Logger.Debug("Configuring local audio");
+                localAudio = new LocalAudio(Config.Audio.RxDevice, Config.Audio.TxDevice, radio, Config.Control.RxOnly);
+            }
 
             // Switch based on control mode
             switch(Config.Control.ControlMode)
             {
+                case RadioControlMode.SDRTrunk:
+                {
+                    radio = new SdrTrunkRadio(
+                        Config.Daemon.Name,
+                        Config.Daemon.Desc,
+                        Config.Daemon.ListenAddress,
+                        Config.Daemon.ListenPort,
+                        Config.Control.SdrTrunk,
+                        Config.Softkeys,
+                        Config.TextLookups.Zone,
+                        Config.TextLookups.Channel
+                    );
+                }
+                break;
                 case RadioControlMode.SB9600:
                 {
                     radio = new MotoSb9600Radio(
@@ -230,7 +247,14 @@ namespace netcore_cli
             }
 
             // Setup RX audio callback
-            localAudio.RxEncodedSampleCallback += radio.RxSendEncodedSamples;
+            if (Config.Control.ControlMode == RadioControlMode.SDRTrunk)
+            {
+                // sdrtrunk mode receives audio from its own Icecast-compatible source listener.
+            }
+            else
+            {
+                localAudio.RxEncodedSampleCallback += radio.RxSendEncodedSamples;
+            }
 
             // Start radio
             radio.Start(noreset);
@@ -241,7 +265,10 @@ namespace netcore_cli
             // Stop radio
             Log.Information("Shutting down...");
             radio.Stop();
-            await localAudio.Stop();
+            if (localAudio != null)
+            {
+                await localAudio.Stop();
+            }
             Log.CloseAndFlush();
 
             Environment.Exit(0);

--- a/daemon/Radio.SdrTrunk.cs
+++ b/daemon/Radio.SdrTrunk.cs
@@ -1,0 +1,906 @@
+using NAudio.Wave;
+using rc2_core;
+using Serilog;
+using System.Net;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace daemon
+{
+    /// <summary>
+    /// Config object used to parse YML config for direct sdrtrunk stream ingest.
+    /// </summary>
+    public class SdrTrunkConfig
+    {
+        /// <summary>
+        /// Address for the Icecast-compatible source listener that sdrtrunk connects to.
+        /// </summary>
+        public IPAddress ListenAddress = IPAddress.Parse("127.0.0.1");
+        /// <summary>
+        /// Port for the Icecast-compatible source listener that sdrtrunk connects to.
+        /// </summary>
+        public int ListenPort = 8000;
+        /// <summary>
+        /// Mount point that sdrtrunk should publish to.
+        /// </summary>
+        public string Mount = "/sdrtrunk";
+        /// <summary>
+        /// Optional Icecast source password. Leave empty to accept local unauthenticated sources.
+        /// </summary>
+        public string SourcePassword = "";
+        /// <summary>
+        /// Static zone name shown in the console for sdrtrunk streams.
+        /// </summary>
+        public string ZoneName = "SDRTrunk";
+        /// <summary>
+        /// Static channel name shown in the console for sdrtrunk streams.
+        /// </summary>
+        public string ChannelName = "Stream";
+        /// <summary>
+        /// Audio level, in dBFS, required to mark the stream receiving.
+        /// </summary>
+        public double RxThresholdDb = -45.0;
+        /// <summary>
+        /// Audio must remain above threshold for this many milliseconds before the gate opens.
+        /// </summary>
+        public int AttackMs = 0;
+        /// <summary>
+        /// The gate remains open this many milliseconds after audio drops below threshold.
+        /// </summary>
+        public int HangMs = 1000;
+        /// <summary>
+        /// Sample rate to forward to RC2 before final WebRTC encoding.
+        /// </summary>
+        public int OutputSampleRate = 16000;
+        /// <summary>
+        /// Restart the sdrtrunk source connection if it stops producing decodable audio for this many milliseconds.
+        /// </summary>
+        public int SourceNoAudioRestartMs = 10000;
+    }
+
+    /// <summary>
+    /// RX-only radio fed by a direct Icecast-compatible source connection from sdrtrunk.
+    /// </summary>
+    internal sealed class SdrTrunkRadio : rc2_core.Radio
+    {
+        private readonly object stateLock = new object();
+        private readonly SdrTrunkConfig streamConfig;
+        private readonly IcecastSourceServer sourceServer;
+        private readonly System.Timers.Timer hangTimer;
+        private long? aboveThresholdSinceMs;
+        private long lastAboveThresholdMs = long.MinValue;
+        private long lastMetadataActiveMs = long.MinValue;
+        private long lastAudioStatsMs = long.MinValue;
+        private long lastSourceStatsMs = long.MinValue;
+        private long sourceConnectedAtMs = long.MinValue;
+        private long lastSourceByteMs = long.MinValue;
+        private long lastDecodedFrameMs = long.MinValue;
+        private long decodedFrameCount;
+        private long forwardedSampleCount;
+        private long sourceBytesRead;
+        private long lastSourceStatsBytes;
+        private byte[] sourcePrefix = Array.Empty<byte>();
+        private bool gateActive;
+        private bool metadataActive;
+        private bool sourceActive;
+        private bool sourceRestartRequested;
+        private bool started;
+
+        public SdrTrunkRadio(
+            string name, string desc,
+            IPAddress listenAddress, int listenPort,
+            SdrTrunkConfig streamConfig,
+            List<SoftkeyName> softkeys,
+            List<TextLookup> zoneLookups = null, List<TextLookup> chanLookups = null
+            ) : base(name, desc, true, listenAddress, listenPort, softkeys, zoneLookups, chanLookups, null, 8000, null)
+        {
+            this.streamConfig = streamConfig ?? new SdrTrunkConfig();
+            RxOnly = true;
+
+            Status.ZoneName = this.streamConfig.ZoneName;
+            Status.ChannelName = this.streamConfig.ChannelName;
+
+            sourceServer = new IcecastSourceServer(
+                this.streamConfig.ListenAddress,
+                this.streamConfig.ListenPort,
+                this.streamConfig.Mount,
+                this.streamConfig.SourcePassword,
+                HandleSource,
+                HandleMetadata);
+
+            hangTimer = new System.Timers.Timer(Math.Clamp(this.streamConfig.HangMs / 4, 50, 250));
+            hangTimer.AutoReset = true;
+            hangTimer.Elapsed += (sender, args) => ExpireGate();
+        }
+
+        public override void Start(bool reset = false)
+        {
+            Log.Information("Starting new sdrtrunk stream radio instance");
+            base.Start(reset);
+
+            lock (stateLock)
+            {
+                started = true;
+                ResetGate();
+                Status.ZoneName = streamConfig.ZoneName;
+                Status.ChannelName = streamConfig.ChannelName;
+                Status.CallerId = "";
+                Status.State = RadioState.Idle;
+            }
+
+            sourceServer.Start();
+            hangTimer.Start();
+            RadioStatusCallback();
+        }
+
+        public override void Stop()
+        {
+            hangTimer.Stop();
+
+            lock (stateLock)
+            {
+                started = false;
+                ResetGate();
+                Status.State = RadioState.Disconnected;
+            }
+
+            RadioStatusCallback();
+            sourceServer.Stop().GetAwaiter().GetResult();
+            base.Stop();
+        }
+
+        public override bool SetTransmit(bool tx)
+        {
+            Log.Debug("Ignoring transmit request because sdrtrunk stream radios are RX-only");
+            return false;
+        }
+
+        public override bool ChangeChannel(bool down)
+        {
+            Log.Debug("Ignoring channel change request because sdrtrunk streams have no channel interface");
+            return false;
+        }
+
+        public override bool PressButton(SoftkeyName name)
+        {
+            Log.Debug("Ignoring button press {name} because sdrtrunk streams have no button interface", name);
+            return false;
+        }
+
+        public override bool ReleaseButton(SoftkeyName name)
+        {
+            Log.Debug("Ignoring button release {name} because sdrtrunk streams have no button interface", name);
+            return false;
+        }
+
+        private async Task HandleSource(IcecastSourceRequest request, CancellationToken token)
+        {
+            if (request.Headers.TryGetValue("content-type", out string contentType) &&
+                !contentType.Contains("mpeg", StringComparison.OrdinalIgnoreCase) &&
+                !contentType.Contains("mp3", StringComparison.OrdinalIgnoreCase))
+            {
+                Log.Warning("sdrtrunk source content type {contentType} is not MP3; attempting MP3 decode anyway", contentType);
+            }
+
+            if (request.Headers.TryGetValue("audio-info", out string audioInfo))
+            {
+                Log.Debug("sdrtrunk source audio-info: {audioInfo}", audioInfo);
+            }
+
+            lock (stateLock)
+            {
+                long nowMs = Environment.TickCount64;
+                sourceActive = true;
+                sourceRestartRequested = false;
+                sourceConnectedAtMs = nowMs;
+                lastSourceByteMs = long.MinValue;
+                lastDecodedFrameMs = long.MinValue;
+                sourceBytesRead = 0;
+                lastSourceStatsBytes = 0;
+                sourcePrefix = Array.Empty<byte>();
+                decodedFrameCount = 0;
+                forwardedSampleCount = 0;
+                lastSourceStatsMs = nowMs;
+            }
+
+            Stream audioStream = request.Body;
+
+            if (TryGetInlineMetadataInterval(request.Headers, out int inlineMetadataInterval))
+            {
+                Log.Information("sdrtrunk source is using inline metadata every {interval} byte(s)", inlineMetadataInterval);
+                audioStream = new InlineMetadataReadStream(request.Body, inlineMetadataInterval, HandleInlineMetadata);
+            }
+
+            try
+            {
+                await Task.Run(() => DecodeMp3Stream(audioStream, token), token);
+            }
+            finally
+            {
+                lock (stateLock)
+                {
+                    sourceActive = false;
+                }
+
+                Log.Debug(
+                    "sdrtrunk source finished: bytesRead={bytes}, decodedFrames={frames}, forwardedSamples={samples}, firstBytes={firstBytes}",
+                    sourceBytesRead,
+                    decodedFrameCount,
+                    forwardedSampleCount,
+                    FormatBytes(sourcePrefix));
+            }
+        }
+
+        private void DecodeMp3Stream(Stream sourceStream, CancellationToken token)
+        {
+            AcmMp3FrameDecompressor decompressor = null;
+            byte[] buffer = null;
+            WaveFormat waveFormat = null;
+
+            try
+            {
+                using PositionTrackingReadStream mp3Stream = new PositionTrackingReadStream(sourceStream, OnSourceBytesRead);
+
+                while (!token.IsCancellationRequested)
+                {
+                    long bytesBeforeFrame = Volatile.Read(ref sourceBytesRead);
+                    Mp3Frame frame = Mp3Frame.LoadFromStream(mp3Stream);
+                    if (frame == null)
+                    {
+                        long bytesAfterFrame = Volatile.Read(ref sourceBytesRead);
+                        if (bytesAfterFrame > bytesBeforeFrame)
+                        {
+                            Log.Warning(
+                                "sdrtrunk source skipped {bytes} non-MP3 byte(s) while looking for a frame; totalBytes={totalBytes}, firstBytes={firstBytes}",
+                                bytesAfterFrame - bytesBeforeFrame,
+                                bytesAfterFrame,
+                                FormatBytes(sourcePrefix));
+                            continue;
+                        }
+
+                        Log.Warning(
+                            "sdrtrunk source ended before another MP3 frame was available; totalBytes={totalBytes}, decodedFrames={frames}, firstBytes={firstBytes}",
+                            bytesAfterFrame,
+                            decodedFrameCount,
+                            FormatBytes(sourcePrefix));
+                        break;
+                    }
+
+                    if (decompressor == null)
+                    {
+                        int channels = frame.ChannelMode == ChannelMode.Mono ? 1 : 2;
+                        WaveFormat mp3Format = new Mp3WaveFormat(frame.SampleRate, channels, frame.FrameLength, frame.BitRate);
+                        decompressor = new AcmMp3FrameDecompressor(mp3Format);
+                        waveFormat = decompressor.OutputFormat;
+                        buffer = new byte[waveFormat.AverageBytesPerSecond];
+
+                        Log.Information(
+                            "Decoding sdrtrunk MP3 source as {sampleRate} Hz, {channels} channel(s)",
+                            waveFormat.SampleRate,
+                            waveFormat.Channels);
+                    }
+
+                    int read = decompressor.DecompressFrame(frame, buffer, 0);
+                    if (read <= 0)
+                    {
+                        continue;
+                    }
+
+                    decodedFrameCount++;
+                    lastDecodedFrameMs = Environment.TickCount64;
+                    short[] monoSamples = ConvertPcm16ToMono(buffer, read, waveFormat);
+                    short[] outputSamples = ResampleLinear(monoSamples, waveFormat.SampleRate, streamConfig.OutputSampleRate);
+                    ProcessSamples(outputSamples);
+                }
+            }
+            finally
+            {
+                decompressor?.Dispose();
+            }
+        }
+
+        private void ProcessSamples(short[] samples)
+        {
+            if (samples == null || samples.Length == 0)
+            {
+                return;
+            }
+
+            long nowMs = Environment.TickCount64;
+            double levelDb = CalculateRmsDb(samples);
+            bool shouldForward;
+            bool statusChanged = false;
+            bool becameActive = false;
+            RadioState nextState;
+
+            lock (stateLock)
+            {
+                if (!started)
+                {
+                    return;
+                }
+
+                bool wasReceiving = IsReceiving();
+                UpdateGate(levelDb, nowMs);
+                nextState = IsReceiving() ? RadioState.Receiving : RadioState.Idle;
+                becameActive = !wasReceiving && nextState == RadioState.Receiving;
+
+                if (Status.State != nextState)
+                {
+                    Status.State = nextState;
+                    statusChanged = true;
+                }
+
+                shouldForward = true;
+            }
+
+            if (statusChanged)
+            {
+                Log.Debug("sdrtrunk stream level {level:0.0} dBFS changed radio state to {state}", levelDb, nextState);
+                RadioStatusCallback();
+            }
+
+            if (shouldForward)
+            {
+                if (becameActive)
+                {
+                    Log.Debug("sdrtrunk stream started forwarding audio at {level:0.0} dBFS", levelDb);
+                }
+
+                RxSendPCM16Samples(samples, (uint)streamConfig.OutputSampleRate);
+                forwardedSampleCount += samples.Length;
+            }
+
+            LogAudioStats(levelDb, nowMs);
+        }
+
+        private void HandleMetadata(IcecastSourceRequest request)
+        {
+            string song = GetQueryValue(request.Mount, "song");
+            ApplyMetadataTitle(song, "metadata");
+        }
+
+        private void HandleInlineMetadata(string metadata)
+        {
+            string song = GetInlineMetadataTitle(metadata);
+            if (string.IsNullOrWhiteSpace(song))
+            {
+                Log.Debug("sdrtrunk inline metadata received without StreamTitle: {metadata}", metadata);
+                return;
+            }
+
+            ApplyMetadataTitle(song, "inline metadata");
+        }
+
+        private void ApplyMetadataTitle(string song, string source)
+        {
+            bool active = !string.IsNullOrWhiteSpace(song) &&
+                !song.Equals("Scanning...", StringComparison.OrdinalIgnoreCase);
+
+            bool statusChanged = false;
+            bool displayChanged = false;
+            RadioState nextState;
+
+            lock (stateLock)
+            {
+                if (active)
+                {
+                    string callerId = ExtractCallerId(song);
+                    metadataActive = true;
+                    lastMetadataActiveMs = Environment.TickCount64;
+                    displayChanged =
+                        !string.Equals(Status.ChannelName, song, StringComparison.Ordinal) ||
+                        !string.Equals(Status.CallerId, callerId, StringComparison.Ordinal);
+                    Status.ChannelName = song;
+                    Status.CallerId = callerId;
+
+                    if (!sourceActive)
+                    {
+                        Log.Warning("sdrtrunk metadata indicates an active call but no SOURCE audio stream is connected");
+                    }
+                }
+                else
+                {
+                    // Keep receiving briefly after Scanning... metadata so queued audio has time to finish.
+                    ExpireGate(Environment.TickCount64);
+                }
+
+                nextState = IsReceiving() ? RadioState.Receiving : RadioState.Idle;
+                if (started && Status.State != nextState)
+                {
+                    Status.State = nextState;
+                    statusChanged = true;
+                }
+            }
+
+            Log.Debug("sdrtrunk {source} changed active={active}: {song}", source, active, string.IsNullOrWhiteSpace(song) ? "(empty)" : song);
+
+            if (statusChanged || displayChanged)
+            {
+                RadioStatusCallback();
+            }
+        }
+
+        private void UpdateGate(double levelDb, long nowMs)
+        {
+            if (levelDb >= streamConfig.RxThresholdDb)
+            {
+                lastAboveThresholdMs = nowMs;
+                aboveThresholdSinceMs ??= nowMs;
+
+                if (!gateActive && nowMs - aboveThresholdSinceMs.Value >= Math.Max(0, streamConfig.AttackMs))
+                {
+                    gateActive = true;
+                }
+
+                return;
+            }
+
+            aboveThresholdSinceMs = null;
+            ExpireGate(nowMs);
+        }
+
+        private void ExpireGate()
+        {
+            bool statusChanged = false;
+
+            lock (stateLock)
+            {
+                if (!started)
+                {
+                    return;
+                }
+
+                statusChanged = ExpireGate(Environment.TickCount64);
+                LogSourceStats(Environment.TickCount64);
+                CheckSourceWatchdog(Environment.TickCount64);
+            }
+
+            if (statusChanged)
+            {
+                Log.Debug("sdrtrunk stream hang timer changed radio state to Idle");
+                RadioStatusCallback();
+            }
+        }
+
+        private bool ExpireGate(long nowMs)
+        {
+            if (metadataActive && lastMetadataActiveMs != long.MinValue && nowMs - lastMetadataActiveMs >= Math.Max(1, streamConfig.HangMs))
+            {
+                metadataActive = false;
+                Status.ChannelName = streamConfig.ChannelName;
+                Status.CallerId = "";
+            }
+
+            if (gateActive && lastAboveThresholdMs != long.MinValue && nowMs - lastAboveThresholdMs >= Math.Max(1, streamConfig.HangMs))
+            {
+                gateActive = false;
+                aboveThresholdSinceMs = null;
+            }
+
+            RadioState nextState = IsReceiving() ? RadioState.Receiving : RadioState.Idle;
+            if (Status.State != nextState)
+            {
+                Status.State = nextState;
+                return true;
+            }
+
+            return false;
+        }
+
+        private void ResetGate()
+        {
+            gateActive = false;
+            metadataActive = false;
+            aboveThresholdSinceMs = null;
+            lastAboveThresholdMs = long.MinValue;
+            lastMetadataActiveMs = long.MinValue;
+        }
+
+        private bool IsReceiving()
+        {
+            return gateActive || metadataActive;
+        }
+
+        private void LogAudioStats(double levelDb, long nowMs)
+        {
+            if (lastAudioStatsMs != long.MinValue && nowMs - lastAudioStatsMs < 2000)
+            {
+                return;
+            }
+
+            lastAudioStatsMs = nowMs;
+            Log.Debug(
+                "sdrtrunk audio stats: level {level:0.0} dBFS, receiving={receiving}, decodedFrames={frames}, forwardedSamples={samples}",
+                levelDb,
+                IsReceiving(),
+                decodedFrameCount,
+                forwardedSampleCount);
+        }
+
+        private void LogSourceStats(long nowMs)
+        {
+            if (!sourceActive || nowMs - lastSourceStatsMs < 5000)
+            {
+                return;
+            }
+
+            long bytesSinceLast = sourceBytesRead - lastSourceStatsBytes;
+            lastSourceStatsBytes = sourceBytesRead;
+            lastSourceStatsMs = nowMs;
+
+            Log.Debug(
+                "sdrtrunk source stats: bytesRead={bytes}, bytesLast5s={bytesLast5s}, decodedFrames={frames}, forwardedSamples={samples}",
+                sourceBytesRead,
+                bytesSinceLast,
+                decodedFrameCount,
+                forwardedSampleCount);
+        }
+
+        private void OnSourceBytesRead(byte[] buffer, int offset, int bytesRead)
+        {
+            if (bytesRead <= 0)
+            {
+                return;
+            }
+
+            Interlocked.Add(ref sourceBytesRead, bytesRead);
+            Interlocked.Exchange(ref lastSourceByteMs, Environment.TickCount64);
+
+            lock (stateLock)
+            {
+                if (sourcePrefix.Length >= 64)
+                {
+                    return;
+                }
+
+                int copyLength = Math.Min(bytesRead, 64 - sourcePrefix.Length);
+                byte[] nextPrefix = new byte[sourcePrefix.Length + copyLength];
+                Buffer.BlockCopy(sourcePrefix, 0, nextPrefix, 0, sourcePrefix.Length);
+                Buffer.BlockCopy(buffer, offset, nextPrefix, sourcePrefix.Length, copyLength);
+                sourcePrefix = nextPrefix;
+            }
+        }
+
+        private void CheckSourceWatchdog(long nowMs)
+        {
+            if (!sourceActive || sourceRestartRequested || streamConfig.SourceNoAudioRestartMs <= 0)
+            {
+                return;
+            }
+
+            long thresholdMs = Math.Max(1000, streamConfig.SourceNoAudioRestartMs);
+            bool noDecodedFrames = decodedFrameCount == 0 && sourceConnectedAtMs != long.MinValue && nowMs - sourceConnectedAtMs >= thresholdMs;
+            bool decodedFramesStalled = decodedFrameCount > 0 && lastDecodedFrameMs != long.MinValue && nowMs - lastDecodedFrameMs >= thresholdMs;
+
+            if (!noDecodedFrames && !decodedFramesStalled)
+            {
+                return;
+            }
+
+            sourceRestartRequested = true;
+            string reason = noDecodedFrames
+                ? $"no decodable MP3 frames after {thresholdMs} ms; bytesRead={sourceBytesRead}, lastByteMs={lastSourceByteMs}, firstBytes={FormatBytes(sourcePrefix)}"
+                : $"no decodable MP3 frames for {thresholdMs} ms; bytesRead={sourceBytesRead}, decodedFrames={decodedFrameCount}";
+
+            Log.Warning("sdrtrunk source watchdog restarting stale source: {reason}", reason);
+            sourceServer.CloseActiveSource(reason);
+        }
+
+        private static string FormatBytes(byte[] bytes)
+        {
+            if (bytes == null || bytes.Length == 0)
+            {
+                return "(none)";
+            }
+
+            return BitConverter.ToString(bytes);
+        }
+
+        private static string GetQueryValue(string pathAndQuery, string key)
+        {
+            int queryStart = pathAndQuery.IndexOf('?');
+            if (queryStart < 0 || queryStart == pathAndQuery.Length - 1)
+            {
+                return "";
+            }
+
+            string query = pathAndQuery.Substring(queryStart + 1);
+            string[] parts = query.Split('&', StringSplitOptions.RemoveEmptyEntries);
+
+            foreach (string part in parts)
+            {
+                int separator = part.IndexOf('=');
+                string partKey = separator >= 0 ? part.Substring(0, separator) : part;
+
+                if (!partKey.Equals(key, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                string value = separator >= 0 ? part.Substring(separator + 1) : "";
+                return WebUtility.UrlDecode(value.Replace("+", " "));
+            }
+
+            return "";
+        }
+
+        private static string ExtractCallerId(string song)
+        {
+            Match match = Regex.Match(song, @"FROM:([^ ]+)");
+            return match.Success ? match.Groups[1].Value : "";
+        }
+
+        private static bool TryGetInlineMetadataInterval(Dictionary<string, string> headers, out int interval)
+        {
+            interval = 0;
+
+            if (!headers.TryGetValue("icy-metaint", out string value))
+            {
+                return false;
+            }
+
+            return int.TryParse(value, out interval) && interval > 0;
+        }
+
+        private static string GetInlineMetadataTitle(string metadata)
+        {
+            if (string.IsNullOrWhiteSpace(metadata))
+            {
+                return "";
+            }
+
+            Match match = Regex.Match(metadata, @"StreamTitle='(?<title>[^']*)';", RegexOptions.IgnoreCase);
+            return match.Success ? match.Groups["title"].Value : "";
+        }
+
+        private static short[] ConvertPcm16ToMono(byte[] buffer, int byteCount, WaveFormat waveFormat)
+        {
+            int channels = Math.Max(1, waveFormat.Channels);
+            int frameSize = channels * sizeof(short);
+            int frameCount = byteCount / frameSize;
+            short[] samples = new short[frameCount];
+
+            for (int frame = 0; frame < frameCount; frame++)
+            {
+                int sum = 0;
+                int frameOffset = frame * frameSize;
+
+                for (int channel = 0; channel < channels; channel++)
+                {
+                    sum += BitConverter.ToInt16(buffer, frameOffset + (channel * sizeof(short)));
+                }
+
+                samples[frame] = (short)(sum / channels);
+            }
+
+            return samples;
+        }
+
+        private static short[] ResampleLinear(short[] samples, int inputRate, int outputRate)
+        {
+            if (samples.Length == 0 || inputRate == outputRate)
+            {
+                return samples;
+            }
+
+            int outputLength = Math.Max(1, (int)Math.Round(samples.Length * (double)outputRate / inputRate));
+            short[] output = new short[outputLength];
+            double ratio = (double)inputRate / outputRate;
+
+            for (int i = 0; i < outputLength; i++)
+            {
+                double sourceIndex = i * ratio;
+                int index = (int)sourceIndex;
+                double fraction = sourceIndex - index;
+
+                if (index >= samples.Length - 1)
+                {
+                    output[i] = samples[samples.Length - 1];
+                    continue;
+                }
+
+                double sample = samples[index] + ((samples[index + 1] - samples[index]) * fraction);
+                output[i] = (short)Math.Clamp(sample, short.MinValue, short.MaxValue);
+            }
+
+            return output;
+        }
+
+        private static double CalculateRmsDb(short[] samples)
+        {
+            double sumSquares = 0.0;
+
+            foreach (short sample in samples)
+            {
+                double normalized = sample / 32768.0;
+                sumSquares += normalized * normalized;
+            }
+
+            double rms = Math.Sqrt(sumSquares / samples.Length);
+            if (rms <= 0.0)
+            {
+                return double.NegativeInfinity;
+            }
+
+            return 20.0 * Math.Log10(rms);
+        }
+
+        private sealed class PositionTrackingReadStream : Stream
+        {
+            private readonly Stream inner;
+            private readonly Action<byte[], int, int> bytesReadCallback;
+
+            public PositionTrackingReadStream(Stream inner, Action<byte[], int, int> bytesReadCallback)
+            {
+                this.inner = inner;
+                this.bytesReadCallback = bytesReadCallback;
+            }
+
+            public override bool CanRead => inner.CanRead;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override long Length => throw new NotSupportedException();
+            public override long Position { get; set; }
+
+            public override void Flush()
+            {
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                int read = inner.Read(buffer, offset, count);
+                Position += read;
+                bytesReadCallback?.Invoke(buffer, offset, read);
+                return read;
+            }
+
+            public override int ReadByte()
+            {
+                int value = inner.ReadByte();
+                if (value >= 0)
+                {
+                    Position++;
+                    byte[] buffer = new byte[] { (byte)value };
+                    bytesReadCallback?.Invoke(buffer, 0, 1);
+                }
+
+                return value;
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void SetLength(long value)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                throw new NotSupportedException();
+            }
+        }
+
+        private sealed class InlineMetadataReadStream : Stream
+        {
+            private readonly Stream inner;
+            private readonly int interval;
+            private readonly Action<string> metadataCallback;
+            private int audioBytesUntilMetadata;
+
+            public InlineMetadataReadStream(Stream inner, int interval, Action<string> metadataCallback)
+            {
+                this.inner = inner;
+                this.interval = interval;
+                this.metadataCallback = metadataCallback;
+                audioBytesUntilMetadata = interval;
+            }
+
+            public override bool CanRead => inner.CanRead;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override long Length => throw new NotSupportedException();
+            public override long Position { get; set; }
+
+            public override void Flush()
+            {
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                int totalRead = 0;
+
+                while (totalRead < count)
+                {
+                    if (audioBytesUntilMetadata == 0)
+                    {
+                        ReadMetadataBlock();
+                        audioBytesUntilMetadata = interval;
+                        continue;
+                    }
+
+                    int readTarget = Math.Min(count - totalRead, audioBytesUntilMetadata);
+                    int read = inner.Read(buffer, offset + totalRead, readTarget);
+                    if (read <= 0)
+                    {
+                        return totalRead > 0 ? totalRead : read;
+                    }
+
+                    totalRead += read;
+                    Position += read;
+                    audioBytesUntilMetadata -= read;
+                }
+
+                return totalRead;
+            }
+
+            public override int ReadByte()
+            {
+                if (audioBytesUntilMetadata == 0)
+                {
+                    ReadMetadataBlock();
+                    audioBytesUntilMetadata = interval;
+                }
+
+                int value = inner.ReadByte();
+                if (value >= 0)
+                {
+                    Position++;
+                    audioBytesUntilMetadata--;
+                }
+
+                return value;
+            }
+
+            private void ReadMetadataBlock()
+            {
+                int lengthByte = inner.ReadByte();
+                if (lengthByte < 0)
+                {
+                    throw new EndOfStreamException();
+                }
+
+                int metadataLength = lengthByte * 16;
+                if (metadataLength == 0)
+                {
+                    return;
+                }
+
+                byte[] metadataBytes = new byte[metadataLength];
+                int offset = 0;
+
+                while (offset < metadataLength)
+                {
+                    int read = inner.Read(metadataBytes, offset, metadataLength - offset);
+                    if (read <= 0)
+                    {
+                        throw new EndOfStreamException();
+                    }
+
+                    offset += read;
+                }
+
+                string metadata = Encoding.UTF8.GetString(metadataBytes).TrimEnd('\0');
+                metadataCallback?.Invoke(metadata);
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void SetLength(long value)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                throw new NotSupportedException();
+            }
+        }
+    }
+}

--- a/daemon/Radio.SdrTrunk.cs
+++ b/daemon/Radio.SdrTrunk.cs
@@ -60,6 +60,9 @@ namespace daemon
 
     /// <summary>
     /// RX-only radio fed by a direct Icecast-compatible source connection from sdrtrunk.
+    /// It receives MP3 frames from sdrtrunk, decodes them to mono PCM, opens the RC2
+    /// receive state when audio crosses the configured threshold, and forwards active
+    /// audio to connected WebRTC clients.
     /// </summary>
     internal sealed class SdrTrunkRadio : rc2_core.Radio
     {
@@ -67,6 +70,8 @@ namespace daemon
         private readonly SdrTrunkConfig streamConfig;
         private readonly IcecastSourceServer sourceServer;
         private readonly System.Timers.Timer hangTimer;
+        // Gate state is driven by decoded audio level; metadata only controls labels so
+        // stale sdrtrunk metadata cannot hold the radio in Receiving without audio.
         private long? aboveThresholdSinceMs;
         private long lastAboveThresholdMs = long.MinValue;
         private long lastMetadataActiveMs = long.MinValue;
@@ -119,6 +124,8 @@ namespace daemon
             Log.Information("Starting new sdrtrunk stream radio instance");
             base.Start(reset);
 
+            // Reset all transient stream state before listening so a previous source
+            // connection cannot leave stale receive/channel state on restart.
             lock (stateLock)
             {
                 started = true;
@@ -176,6 +183,9 @@ namespace daemon
 
         private async Task HandleSource(IcecastSourceRequest request, CancellationToken token)
         {
+            // This method owns one accepted source connection from IcecastSourceServer.
+            // It validates useful headers, resets per-connection counters, optionally
+            // strips inline metadata, and then blocks while the MP3 body is decoded.
             if (request.Headers.TryGetValue("content-type", out string contentType) &&
                 !contentType.Contains("mpeg", StringComparison.OrdinalIgnoreCase) &&
                 !contentType.Contains("mp3", StringComparison.OrdinalIgnoreCase))
@@ -234,6 +244,8 @@ namespace daemon
 
         private void DecodeMp3Stream(Stream sourceStream, CancellationToken token)
         {
+            // NAudio's MP3 decompressor locks to the format of the first frame, which is
+            // fine for sdrtrunk streams and avoids reopening ACM state for every packet.
             AcmMp3FrameDecompressor decompressor = null;
             byte[] buffer = null;
             WaveFormat waveFormat = null;
@@ -307,6 +319,9 @@ namespace daemon
                 return;
             }
 
+            // Every decoded PCM block updates the audio gate first. Only samples that
+            // arrive while the gate is open are forwarded, which prevents scanning noise
+            // or idle MP3 padding from creating console RX traffic.
             long nowMs = Environment.TickCount64;
             double levelDb = CalculateRmsDb(samples);
             bool shouldForward;
@@ -363,12 +378,16 @@ namespace daemon
 
         private void HandleMetadata(IcecastSourceRequest request)
         {
+            // sdrtrunk sends external metadata through Icecast's admin endpoint as a
+            // query-string song value, usually containing the active talkgroup/caller.
             string song = GetQueryValue(request.Mount, "song");
             ApplyMetadataTitle(song, "metadata");
         }
 
         private void HandleInlineMetadata(string metadata)
         {
+            // Some source configurations carry the same title data inside the stream
+            // using ICY metadata blocks instead of separate admin requests.
             string song = GetInlineMetadataTitle(metadata);
             if (string.IsNullOrWhiteSpace(song))
             {
@@ -381,6 +400,8 @@ namespace daemon
 
         private void ApplyMetadataTitle(string song, string source)
         {
+            // sdrtrunk posts "Scanning..." between calls. Treat it as inactive metadata
+            // while keeping any already-buffered call audio alive through the hang timer.
             bool active = !string.IsNullOrWhiteSpace(song) &&
                 !song.Equals("Scanning...", StringComparison.OrdinalIgnoreCase);
 
@@ -449,6 +470,8 @@ namespace daemon
         {
             displayChanged = false;
 
+            // Attack time requires audio to stay above threshold before opening RX.
+            // Hang time is applied by ExpireGate once audio falls below threshold.
             if (levelDb >= streamConfig.RxThresholdDb)
             {
                 lastAboveThresholdMs = nowMs;
@@ -505,6 +528,9 @@ namespace daemon
         {
             displayChanged = false;
 
+            // The audio gate and display metadata expire separately: audio controls the
+            // radio state, and metadata is allowed to linger only long enough to label
+            // delayed buffered audio already being forwarded.
             if (gateActive && lastAboveThresholdMs != long.MinValue && nowMs - lastAboveThresholdMs >= Math.Max(1, streamConfig.HangMs))
             {
                 gateActive = false;
@@ -603,6 +629,8 @@ namespace daemon
 
             lock (stateLock)
             {
+                // Keep a short prefix for diagnostics when a source connects but sends
+                // unexpected bytes instead of MP3 frames.
                 if (sourcePrefix.Length >= 64)
                 {
                     return;
@@ -623,6 +651,8 @@ namespace daemon
                 return;
             }
 
+            // If bytes continue arriving but no MP3 frames decode, closing the source is
+            // the least invasive way to make sdrtrunk reconnect and renegotiate headers.
             long thresholdMs = Math.Max(1000, streamConfig.SourceNoAudioRestartMs);
             bool noDecodedFrames = decodedFrameCount == 0 && sourceConnectedAtMs != long.MinValue && nowMs - sourceConnectedAtMs >= thresholdMs;
             bool decodedFramesStalled = decodedFrameCount > 0 && lastDecodedFrameMs != long.MinValue && nowMs - lastDecodedFrameMs >= thresholdMs;
@@ -653,6 +683,8 @@ namespace daemon
 
         private static string GetQueryValue(string pathAndQuery, string key)
         {
+            // Metadata requests arrive as a path plus query string rather than a parsed
+            // Uri because Icecast mount paths can be relative and do not include a host.
             int queryStart = pathAndQuery.IndexOf('?');
             if (queryStart < 0 || queryStart == pathAndQuery.Length - 1)
             {
@@ -710,6 +742,8 @@ namespace daemon
 
         private static short[] ConvertPcm16ToMono(byte[] buffer, int byteCount, WaveFormat waveFormat)
         {
+            // RC2 forwards mono PCM. If sdrtrunk sends stereo MP3, average the channels
+            // before resampling so downstream audio handling stays unchanged.
             int channels = Math.Max(1, waveFormat.Channels);
             int frameSize = channels * sizeof(short);
             int frameCount = byteCount / frameSize;
@@ -738,6 +772,8 @@ namespace daemon
                 return samples;
             }
 
+            // The source stream rate is controlled by sdrtrunk; normalize it to the rate
+            // expected by the RC2 WebRTC path without pulling in another resampler here.
             int outputLength = Math.Max(1, (int)Math.Round(samples.Length * (double)outputRate / inputRate));
             short[] output = new short[outputLength];
             double ratio = (double)inputRate / outputRate;
@@ -782,6 +818,8 @@ namespace daemon
 
         private sealed class PositionTrackingReadStream : Stream
         {
+            // Mp3Frame.LoadFromStream reads directly from the stream. Wrapping the source
+            // lets the watchdog and diagnostics know whether bytes are still arriving.
             private readonly Stream inner;
             private readonly Action<byte[], int, int> bytesReadCallback;
 
@@ -867,6 +905,8 @@ namespace daemon
             {
                 int totalRead = 0;
 
+                // Icecast inline metadata is interleaved after every N audio bytes. This
+                // stream strips those metadata blocks so the MP3 decoder sees audio only.
                 while (totalRead < count)
                 {
                     if (audioBytesUntilMetadata == 0)

--- a/daemon/Radio.SdrTrunk.cs
+++ b/daemon/Radio.SdrTrunk.cs
@@ -94,11 +94,11 @@ namespace daemon
 
         public SdrTrunkRadio(
             string name, string desc,
-            IPAddress listenAddress, int listenPort,
+            IPAddress listenAddress, int listenPort, List<IPNetwork> allowedNetworks,
             SdrTrunkConfig streamConfig,
             List<SoftkeyName> softkeys,
             List<TextLookup> zoneLookups = null, List<TextLookup> chanLookups = null
-            ) : base(name, desc, true, listenAddress, listenPort, softkeys, zoneLookups, chanLookups, null, 8000, null)
+            ) : base(name, desc, true, listenAddress, listenPort, allowedNetworks, softkeys, zoneLookups, chanLookups, null, 8000, null)
         {
             this.streamConfig = streamConfig ?? new SdrTrunkConfig();
             RxOnly = true;

--- a/daemon/Radio.SdrTrunk.cs
+++ b/daemon/Radio.SdrTrunk.cs
@@ -80,6 +80,7 @@ namespace daemon
         private long sourceBytesRead;
         private long lastSourceStatsBytes;
         private byte[] sourcePrefix = Array.Empty<byte>();
+        private string lastMetadataTitle = "";
         private bool gateActive;
         private bool metadataActive;
         private bool sourceActive;
@@ -310,6 +311,7 @@ namespace daemon
             double levelDb = CalculateRmsDb(samples);
             bool shouldForward;
             bool statusChanged = false;
+            bool displayChanged = false;
             bool becameActive = false;
             RadioState nextState;
 
@@ -321,8 +323,9 @@ namespace daemon
                 }
 
                 bool wasReceiving = IsReceiving();
-                UpdateGate(levelDb, nowMs);
-                nextState = IsReceiving() ? RadioState.Receiving : RadioState.Idle;
+                statusChanged = UpdateGate(levelDb, nowMs, out displayChanged);
+                bool receiving = IsReceiving();
+                nextState = receiving ? RadioState.Receiving : RadioState.Idle;
                 becameActive = !wasReceiving && nextState == RadioState.Receiving;
 
                 if (Status.State != nextState)
@@ -331,12 +334,16 @@ namespace daemon
                     statusChanged = true;
                 }
 
-                shouldForward = true;
+                shouldForward = receiving;
             }
 
-            if (statusChanged)
+            if (statusChanged || displayChanged)
             {
-                Log.Debug("sdrtrunk stream level {level:0.0} dBFS changed radio state to {state}", levelDb, nextState);
+                if (statusChanged)
+                {
+                    Log.Debug("sdrtrunk stream level {level:0.0} dBFS changed radio state to {state}", levelDb, nextState);
+                }
+
                 RadioStatusCallback();
             }
 
@@ -380,29 +387,46 @@ namespace daemon
             bool statusChanged = false;
             bool displayChanged = false;
             RadioState nextState;
+            long nowMs = Environment.TickCount64;
 
             lock (stateLock)
             {
                 if (active)
                 {
                     string callerId = ExtractCallerId(song);
-                    metadataActive = true;
-                    lastMetadataActiveMs = Environment.TickCount64;
-                    displayChanged =
-                        !string.Equals(Status.ChannelName, song, StringComparison.Ordinal) ||
-                        !string.Equals(Status.CallerId, callerId, StringComparison.Ordinal);
-                    Status.ChannelName = song;
-                    Status.CallerId = callerId;
+                    bool titleChanged = !string.Equals(song, lastMetadataTitle, StringComparison.Ordinal);
+                    bool audioRecent = HasRecentAudioActivity(nowMs);
 
-                    if (!sourceActive)
+                    if (titleChanged || audioRecent)
+                    {
+                        metadataActive = true;
+                        lastMetadataActiveMs = nowMs;
+                        lastMetadataTitle = song;
+                        displayChanged =
+                            !string.Equals(Status.ChannelName, song, StringComparison.Ordinal) ||
+                            !string.Equals(Status.CallerId, callerId, StringComparison.Ordinal);
+                        Status.ChannelName = song;
+                        Status.CallerId = callerId;
+                    }
+
+                    if (!sourceActive && (titleChanged || audioRecent))
                     {
                         Log.Warning("sdrtrunk metadata indicates an active call but no SOURCE audio stream is connected");
                     }
                 }
                 else
                 {
-                    // Keep receiving briefly after Scanning... metadata so queued audio has time to finish.
-                    ExpireGate(Environment.TickCount64);
+                    // Keep the displayed talkgroup while queued audio drains, but allow the
+                    // next real call on the same talkgroup to be accepted as fresh metadata.
+                    if (metadataActive && lastMetadataActiveMs != long.MinValue)
+                    {
+                        lastMetadataActiveMs = Math.Min(lastMetadataActiveMs, nowMs - Math.Max(1, streamConfig.HangMs));
+                    }
+
+                    lastMetadataTitle = "";
+
+                    statusChanged = ExpireGate(nowMs, out bool expiredDisplayChanged);
+                    displayChanged |= expiredDisplayChanged;
                 }
 
                 nextState = IsReceiving() ? RadioState.Receiving : RadioState.Idle;
@@ -421,8 +445,10 @@ namespace daemon
             }
         }
 
-        private void UpdateGate(double levelDb, long nowMs)
+        private bool UpdateGate(double levelDb, long nowMs, out bool displayChanged)
         {
+            displayChanged = false;
+
             if (levelDb >= streamConfig.RxThresholdDb)
             {
                 lastAboveThresholdMs = nowMs;
@@ -433,16 +459,17 @@ namespace daemon
                     gateActive = true;
                 }
 
-                return;
+                return false;
             }
 
             aboveThresholdSinceMs = null;
-            ExpireGate(nowMs);
+            return ExpireGate(nowMs, out displayChanged);
         }
 
         private void ExpireGate()
         {
             bool statusChanged = false;
+            bool callbackNeeded = false;
 
             lock (stateLock)
             {
@@ -451,31 +478,50 @@ namespace daemon
                     return;
                 }
 
-                statusChanged = ExpireGate(Environment.TickCount64);
-                LogSourceStats(Environment.TickCount64);
-                CheckSourceWatchdog(Environment.TickCount64);
+                long nowMs = Environment.TickCount64;
+                statusChanged = ExpireGate(nowMs, out bool displayChanged);
+                LogSourceStats(nowMs);
+                CheckSourceWatchdog(nowMs);
+                callbackNeeded = statusChanged || displayChanged;
             }
 
-            if (statusChanged)
+            if (callbackNeeded)
             {
-                Log.Debug("sdrtrunk stream hang timer changed radio state to Idle");
+                if (statusChanged)
+                {
+                    Log.Debug("sdrtrunk stream hang timer changed radio state to Idle");
+                }
+
                 RadioStatusCallback();
             }
         }
 
         private bool ExpireGate(long nowMs)
         {
-            if (metadataActive && lastMetadataActiveMs != long.MinValue && nowMs - lastMetadataActiveMs >= Math.Max(1, streamConfig.HangMs))
-            {
-                metadataActive = false;
-                Status.ChannelName = streamConfig.ChannelName;
-                Status.CallerId = "";
-            }
+            return ExpireGate(nowMs, out _);
+        }
+
+        private bool ExpireGate(long nowMs, out bool displayChanged)
+        {
+            displayChanged = false;
 
             if (gateActive && lastAboveThresholdMs != long.MinValue && nowMs - lastAboveThresholdMs >= Math.Max(1, streamConfig.HangMs))
             {
                 gateActive = false;
                 aboveThresholdSinceMs = null;
+            }
+
+            if (metadataActive &&
+                !gateActive &&
+                lastMetadataActiveMs != long.MinValue &&
+                nowMs - lastMetadataActiveMs >= Math.Max(1, streamConfig.HangMs))
+            {
+                metadataActive = false;
+                displayChanged =
+                    !string.Equals(Status.ChannelName, streamConfig.ChannelName, StringComparison.Ordinal) ||
+                    !string.IsNullOrEmpty(Status.CallerId);
+                Status.ChannelName = streamConfig.ChannelName;
+                Status.CallerId = "";
             }
 
             RadioState nextState = IsReceiving() ? RadioState.Receiving : RadioState.Idle;
@@ -495,11 +541,19 @@ namespace daemon
             aboveThresholdSinceMs = null;
             lastAboveThresholdMs = long.MinValue;
             lastMetadataActiveMs = long.MinValue;
+            lastMetadataTitle = "";
         }
 
         private bool IsReceiving()
         {
-            return gateActive || metadataActive;
+            return gateActive;
+        }
+
+        private bool HasRecentAudioActivity(long nowMs)
+        {
+            return gateActive ||
+                (lastAboveThresholdMs != long.MinValue &&
+                nowMs - lastAboveThresholdMs < Math.Max(1, streamConfig.HangMs));
         }
 
         private void LogAudioStats(double levelDb, long nowMs)

--- a/daemon/config.example.yml
+++ b/daemon/config.example.yml
@@ -22,10 +22,35 @@ control:
     #   2 - SB9600 (emulation of Motorola Astro W-series and MCS2000 model-3 control heads over SB9600)
     #   3 - XCMP Serial (control of Motorola XTL radios via serial)
     #   4 - XCMP USB (control of Motorola XPR and APX radios via USB)
+    #   5 - SDRTrunk (RX-only direct Icecast-compatible source ingest from sdrtrunk)
     controlMode: 2
 
     # RX Only (TX disabled)
     rxOnly: false
+
+    # SDRTrunk direct stream configuration
+    sdrTrunk:
+        # Address/port where sdrtrunk should connect as an Icecast source.
+        listenAddress: 127.0.0.1
+        listenPort: 8000
+        # Mount point configured in sdrtrunk.
+        mount: "/sdrtrunk"
+        # Optional source password. Leave empty to accept local unauthenticated sources.
+        sourcePassword: ""
+        # Static zone/channel labels shown by the console.
+        zoneName: "SDRTrunk"
+        channelName: "Stream"
+        # Audio level in dBFS required to mark the stream receiving.
+        rxThresholdDb: -45
+        # Audio must stay above threshold for attackMs before opening,
+        # and stays open for hangMs after dropping below threshold.
+        attackMs: 0
+        hangMs: 3000
+        # Sample rate forwarded to RC2 before final WebRTC encoding.
+        outputSampleRate: 16000
+        # If sdrtrunk connects but sends no decodable MP3 frames, close the
+        # source so sdrtrunk reconnects without manually toggling the stream.
+        sourceNoAudioRestartMs: 10000
 
     # SB9600 configuration
     sb9600:

--- a/daemon/config.sdrtrunk.yml
+++ b/daemon/config.sdrtrunk.yml
@@ -1,0 +1,53 @@
+#
+#   RadioConsole2 Daemon Config File - SDRTrunk Direct Stream
+#
+
+daemon:
+    name: "SDRTrunk"
+    desc: "Direct sdrtrunk audio stream"
+    # RC2 console connects to this address/port.
+    listenAddress: 0.0.0.0
+    listenPort: 8804
+
+audio:
+    # Not used by SDRTrunk mode.
+    txDevice: ""
+    rxDevice: ""
+
+control:
+    # 5 - SDRTrunk direct Icecast-compatible source ingest
+    controlMode: 5
+    rxOnly: true
+
+    sdrTrunk:
+        # sdrtrunk should publish its stream to this listener.
+        listenAddress: 127.0.0.1
+        listenPort: 8000
+        mount: "/sdrtrunk"
+
+        # Leave empty for local testing. Set this if you configure a source
+        # password in sdrtrunk.
+        sourcePassword: ""
+
+        # Static labels shown in RC2.
+        zoneName: "SDRTrunk"
+        channelName: "Stream"
+
+        # Less negative is less sensitive; more negative is more sensitive.
+        rxThresholdDb: -45
+
+        # Open quickly on activity, then hold through short stream gaps.
+        attackMs: 0
+        hangMs: 3000
+
+        # Audio rate sent into RC2 before WebRTC encoding.
+        outputSampleRate: 16000
+
+        # If sdrtrunk connects but sends no decodable MP3 frames, close the
+        # source so sdrtrunk reconnects without manually toggling the stream.
+        sourceNoAudioRestartMs: 10000
+
+softkeys:
+    - MON
+    - HOME
+    - SEL

--- a/daemon/sdr-trunk.yml
+++ b/daemon/sdr-trunk.yml
@@ -1,0 +1,92 @@
+#
+#   RadioConsole2 SDRTrunk Feed Launcher Config
+#
+# Run with:
+#   .\start-sdrtrunk-feeds.ps1 -Config .\sdrtrunk-feeds.yml
+#
+
+# Path to the daemon executable. Relative paths are resolved from this file.
+daemonPath: ".\\daemon.exe"
+
+# Generated per-feed daemon configs and logs. Relative paths are resolved from this file.
+generatedConfigDirectory: ".\\generated-sdrtrunk"
+logDirectory: ".\\logs"
+
+# Add/update these feeds in the RC2 console radio config before starting daemons.
+updateRc2Config: true
+rc2ConfigPath: "%APPDATA%\\rc2-console\\config.json"
+
+# Pass -d to each daemon instance.
+debug: true
+
+defaults:
+  rc2ListenAddress: "0.0.0.0"
+  sourceListenAddress: "0.0.0.0"
+  sourcePassword: ""
+  rxThresholdDb: -45
+  attackMs: 0
+  hangMs: 3000
+  outputSampleRate: 16000
+  sourceNoAudioRestartMs: 10000
+  softkeys: ["MON", "HOME", "SEL"]
+
+feeds:
+  - id: 81FIREMS
+    enabled: true
+    name: "81FIREMS"
+    desc: "SDRTrunk fire talkgroups"
+    rc2Port: 7804
+    sourcePort: 8004
+    mount: "/81FIREMS"
+    zoneName: "Van Wert County"
+    channelName: "81FIREMS"
+    color: "purple"
+    pan: 0
+
+  - id: SO81DISP
+    enabled: true
+    name: "SO81DISP"
+    desc: "SDRTrunk law talkgroups"
+    rc2Port: 7805
+    sourcePort: 8005
+    mount: "/SO81DISP"
+    zoneName: "Van Wert County"
+    channelName: "SO81DISP"
+    color: "purple"
+    pan: 0
+
+  - id: VWFDPG3
+    enabled: true
+    name: "VWFDPG3"
+    desc: "SDRTrunk Paging talkgroups"
+    rc2Port: 7806
+    sourcePort: 8006
+    mount: "/VWFDPG3"
+    zoneName: "Van Wert County"
+    channelName: "VWFDPG3"
+    color: "purple"
+    pan: 0
+
+  - id: VWCPD1
+    enabled: true
+    name: "VWCPD1"
+    desc: "SDRTrunk Police talkgroups"
+    rc2Port: 7807
+    sourcePort: 8007
+    mount: "/VWCPD1"
+    zoneName: "Van Wert County"
+    channelName: "VWCPD1"
+    color: "purple"
+    pan: 0
+
+  - id: 81EMA
+    enabled: true
+    name: "81EMA"
+    desc: "SDRTrunk EMA talkgroups"
+    rc2Port: 7808
+    sourcePort: 8008
+    mount: "/81EMA"
+    zoneName: "Van Wert County"
+    channelName: "81EMA"
+    color: "purple"
+    pan: 081

--- a/daemon/sdrtrunk-feeds.example.yml
+++ b/daemon/sdrtrunk-feeds.example.yml
@@ -1,0 +1,76 @@
+#
+#   RadioConsole2 SDRTrunk Feed Launcher Config
+#
+# Run with:
+#   .\start-sdrtrunk-feeds.ps1 -Config .\sdrtrunk-feeds.yml
+# Or double-click:
+#   start-sdrtrunk-feeds.cmd
+#
+
+# Path to the daemon executable. Relative paths are resolved from this file.
+daemonPath: ".\\daemon.exe"
+
+# Generated per-feed daemon configs and logs. Relative paths are resolved from this file.
+generatedConfigDirectory: ".\\generated-sdrtrunk"
+logDirectory: ".\\logs"
+
+# Add/update these feeds in the RC2 console radio config before starting daemons.
+updateRc2Config: true
+rc2ConfigPath: "%APPDATA%\\rc2-console\\config.json"
+
+# Pass -d to each daemon instance.
+debug: true
+
+defaults:
+  rc2ListenAddress: "0.0.0.0"
+  rc2Address: "127.0.0.1"
+  sourceListenAddress: "0.0.0.0"
+  sourcePassword: ""
+  rxThresholdDb: -45
+  attackMs: 0
+  hangMs: 3000
+  outputSampleRate: 16000
+  # Newer SDRTrunk daemon builds have this default built in. Set
+  # emitSourceNoAudioRestartMs: true only if your daemon supports the config key.
+  sourceNoAudioRestartMs: 10000
+  emitSourceNoAudioRestartMs: false
+  softkeys: ["MON", "HOME", "SEL"]
+  color: "blue"
+  pan: 0
+
+feeds:
+  - id: fire
+    enabled: true
+    name: "SDRTrunk Fire"
+    desc: "SDRTrunk fire talkgroups"
+    rc2Port: 8804
+    sourcePort: 8004
+    mount: "/fire"
+    zoneName: "SDRTrunk"
+    channelName: "Fire"
+    color: "red"
+    pan: -0.5
+
+  - id: law
+    enabled: true
+    name: "SDRTrunk Law"
+    desc: "SDRTrunk law talkgroups"
+    rc2Port: 8805
+    sourcePort: 8005
+    mount: "/law"
+    zoneName: "SDRTrunk"
+    channelName: "Law"
+    color: "purple"
+    pan: 0
+
+  - id: ems
+    enabled: true
+    name: "SDRTrunk EMS"
+    desc: "SDRTrunk EMS talkgroups"
+    rc2Port: 8806
+    sourcePort: 8006
+    mount: "/ems"
+    zoneName: "SDRTrunk"
+    channelName: "EMS"
+    color: "green"
+    pan: 0.5

--- a/daemon/start-sdrtrunk-feeds.cmd
+++ b/daemon/start-sdrtrunk-feeds.cmd
@@ -1,0 +1,17 @@
+@echo off
+setlocal
+pushd "%~dp0"
+
+if not exist "%~dp0sdrtrunk-feeds.yml" (
+    echo Missing "%~dp0sdrtrunk-feeds.yml"
+    echo Copy sdrtrunk-feeds.example.yml to sdrtrunk-feeds.yml and edit it first.
+    pause
+    exit /b 1
+)
+
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0start-sdrtrunk-feeds.ps1" -Config "%~dp0sdrtrunk-feeds.yml" %*
+set "RC=%ERRORLEVEL%"
+
+popd
+if not "%RC%"=="0" pause
+exit /b %RC%

--- a/daemon/start-sdrtrunk-feeds.ps1
+++ b/daemon/start-sdrtrunk-feeds.ps1
@@ -10,6 +10,8 @@ param(
 Set-StrictMode -Version 2.0
 $ErrorActionPreference = "Stop"
 
+# The launcher intentionally uses a tiny YAML reader so Windows installs do not need an
+# extra PowerShell module before they can generate per-feed daemon configs.
 function Remove-Rc2YamlComment {
     param([string]$Line)
 
@@ -69,6 +71,8 @@ function ConvertFrom-Rc2YamlScalar {
 function ConvertFrom-Rc2FeedYaml {
     param([string]$Path)
 
+    # The feed file only uses a small subset of YAML: top-level defaults and a list of
+    # feeds. Parse just that shape and fail loudly if an unsupported line is added.
     $root = [ordered]@{
         defaults = [ordered]@{}
         feeds = @()
@@ -128,6 +132,8 @@ function Resolve-Rc2Path {
         [string]$BaseDirectory
     )
 
+    # Paths in the feed file are relative to that file, not the caller's current
+    # directory, so the launcher behaves the same from a shell or a shortcut.
     $expandedPath = [Environment]::ExpandEnvironmentVariables($Path)
     if ([System.IO.Path]::IsPathRooted($expandedPath)) {
         return [System.IO.Path]::GetFullPath($expandedPath)

--- a/daemon/start-sdrtrunk-feeds.ps1
+++ b/daemon/start-sdrtrunk-feeds.ps1
@@ -1,0 +1,772 @@
+param(
+    [string]$Config = "sdrtrunk-feeds.yml",
+    [string]$DaemonPath,
+    [string]$Rc2ConfigPath,
+    [switch]$GenerateOnly,
+    [switch]$NoRc2ConfigUpdate,
+    [switch]$NoJobObject
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = "Stop"
+
+function Remove-Rc2YamlComment {
+    param([string]$Line)
+
+    $inSingle = $false
+    $inDouble = $false
+    for ($i = 0; $i -lt $Line.Length; $i++) {
+        $ch = $Line[$i]
+        if ($ch -eq "'" -and -not $inDouble) {
+            $inSingle = -not $inSingle
+        }
+        elseif ($ch -eq '"' -and -not $inSingle) {
+            $escaped = $i -gt 0 -and $Line[$i - 1] -eq '\'
+            if (-not $escaped) {
+                $inDouble = -not $inDouble
+            }
+        }
+        elseif ($ch -eq "#" -and -not $inSingle -and -not $inDouble) {
+            return $Line.Substring(0, $i)
+        }
+    }
+
+    return $Line
+}
+
+function ConvertFrom-Rc2YamlScalar {
+    param([string]$Value)
+
+    $value = $Value.Trim()
+    if ($value.Length -eq 0) {
+        return ""
+    }
+
+    if ($value.StartsWith("[") -and $value.EndsWith("]")) {
+        $inner = $value.Substring(1, $value.Length - 2).Trim()
+        if ($inner.Length -eq 0) {
+            return @()
+        }
+
+        return @($inner -split "," | ForEach-Object { ConvertFrom-Rc2YamlScalar $_ })
+    }
+
+    if (($value.StartsWith('"') -and $value.EndsWith('"')) -or ($value.StartsWith("'") -and $value.EndsWith("'"))) {
+        $unquoted = $value.Substring(1, $value.Length - 2)
+        return $unquoted.Replace('\"', '"').Replace("\\", "\")
+    }
+
+    switch -Regex ($value) {
+        "^(?i:true)$" { return $true }
+        "^(?i:false)$" { return $false }
+        "^(?i:null|~)$" { return $null }
+        "^-?\d+$" { return [int]$value }
+        "^-?\d+\.\d+$" { return [double]$value }
+        default { return $value }
+    }
+}
+
+function ConvertFrom-Rc2FeedYaml {
+    param([string]$Path)
+
+    $root = [ordered]@{
+        defaults = [ordered]@{}
+        feeds = @()
+    }
+    $section = $null
+    $currentFeed = $null
+
+    foreach ($rawLine in Get-Content -LiteralPath $Path) {
+        $line = Remove-Rc2YamlComment $rawLine
+        if ([string]::IsNullOrWhiteSpace($line)) {
+            continue
+        }
+
+        if ($line -match "^(?<key>[A-Za-z0-9_]+):\s*(?<value>.*)$") {
+            $key = $Matches.key
+            $value = $Matches.value
+            if ($key -eq "defaults" -or $key -eq "feeds") {
+                $section = $key
+                $currentFeed = $null
+                continue
+            }
+
+            $root[$key] = ConvertFrom-Rc2YamlScalar $value
+            $section = $null
+            $currentFeed = $null
+            continue
+        }
+
+        if ($section -eq "defaults" -and $line -match "^\s+(?<key>[A-Za-z0-9_]+):\s*(?<value>.*)$") {
+            $root.defaults[$Matches.key] = ConvertFrom-Rc2YamlScalar $Matches.value
+            continue
+        }
+
+        if ($section -eq "feeds" -and $line -match "^\s*-\s+(?<rest>.+)$") {
+            $currentFeed = [ordered]@{}
+            $root.feeds += $currentFeed
+            if ($Matches.rest -match "^(?<key>[A-Za-z0-9_]+):\s*(?<value>.*)$") {
+                $currentFeed[$Matches.key] = ConvertFrom-Rc2YamlScalar $Matches.value
+            }
+            continue
+        }
+
+        if ($section -eq "feeds" -and $null -ne $currentFeed -and $line -match "^\s+(?<key>[A-Za-z0-9_]+):\s*(?<value>.*)$") {
+            $currentFeed[$Matches.key] = ConvertFrom-Rc2YamlScalar $Matches.value
+            continue
+        }
+
+        throw "Unsupported YAML line in ${Path}: $rawLine"
+    }
+
+    return $root
+}
+
+function Resolve-Rc2Path {
+    param(
+        [string]$Path,
+        [string]$BaseDirectory
+    )
+
+    $expandedPath = [Environment]::ExpandEnvironmentVariables($Path)
+    if ([System.IO.Path]::IsPathRooted($expandedPath)) {
+        return [System.IO.Path]::GetFullPath($expandedPath)
+    }
+
+    return [System.IO.Path]::GetFullPath((Join-Path $BaseDirectory $expandedPath))
+}
+
+function Resolve-Rc2LauncherConfigPath {
+    param([string]$Path)
+
+    $expandedPath = [Environment]::ExpandEnvironmentVariables($Path)
+    if ([System.IO.Path]::IsPathRooted($expandedPath)) {
+        return [System.IO.Path]::GetFullPath($expandedPath)
+    }
+
+    $currentDirectoryPath = [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $expandedPath))
+    if (Test-Path -LiteralPath $currentDirectoryPath) {
+        return $currentDirectoryPath
+    }
+
+    return [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot $expandedPath))
+}
+
+function Get-Rc2Value {
+    param(
+        [System.Collections.IDictionary]$Feed,
+        [System.Collections.IDictionary]$Defaults,
+        [string]$Name,
+        $Fallback = $null
+    )
+
+    if ($Feed.Contains($Name) -and $null -ne $Feed[$Name]) {
+        return $Feed[$Name]
+    }
+
+    if ($Defaults.Contains($Name) -and $null -ne $Defaults[$Name]) {
+        return $Defaults[$Name]
+    }
+
+    return $Fallback
+}
+
+function ConvertTo-Rc2YamlString {
+    param($Value)
+
+    if ($null -eq $Value) {
+        return '""'
+    }
+
+    $escaped = ([string]$Value).Replace("\", "\\").Replace('"', '\"')
+    return '"' + $escaped + '"'
+}
+
+function Write-Rc2DaemonConfig {
+    param(
+        [System.Collections.IDictionary]$Feed,
+        [System.Collections.IDictionary]$Defaults,
+        [string]$Path
+    )
+
+    $name = Get-Rc2Value $Feed $Defaults "name" $Feed.id
+    $desc = Get-Rc2Value $Feed $Defaults "desc" "SDRTrunk direct stream"
+    $rc2ListenAddress = Get-Rc2Value $Feed $Defaults "rc2ListenAddress" "0.0.0.0"
+    $rc2Port = Get-Rc2Value $Feed $Defaults "rc2Port" $null
+    $sourceListenAddress = Get-Rc2Value $Feed $Defaults "sourceListenAddress" "0.0.0.0"
+    $sourcePort = Get-Rc2Value $Feed $Defaults "sourcePort" $null
+    $mount = Get-Rc2Value $Feed $Defaults "mount" ("/" + $Feed.id)
+    $sourcePassword = Get-Rc2Value $Feed $Defaults "sourcePassword" ""
+    $zoneName = Get-Rc2Value $Feed $Defaults "zoneName" "SDRTrunk"
+    $channelName = Get-Rc2Value $Feed $Defaults "channelName" $Feed.id
+    $rxThresholdDb = Get-Rc2Value $Feed $Defaults "rxThresholdDb" -45
+    $attackMs = Get-Rc2Value $Feed $Defaults "attackMs" 0
+    $hangMs = Get-Rc2Value $Feed $Defaults "hangMs" 3000
+    $outputSampleRate = Get-Rc2Value $Feed $Defaults "outputSampleRate" 16000
+    $emitSourceNoAudioRestartMs = [bool](Get-Rc2Value $Feed $Defaults "emitSourceNoAudioRestartMs" $false)
+    $sourceNoAudioRestartMs = Get-Rc2Value $Feed $Defaults "sourceNoAudioRestartMs" 10000
+    $softkeys = @(Get-Rc2Value $Feed $Defaults "softkeys" @("MON", "HOME", "SEL"))
+
+    if ($null -eq $rc2Port) {
+        throw "Feed '$($Feed.id)' is missing rc2Port"
+    }
+    if ($null -eq $sourcePort) {
+        throw "Feed '$($Feed.id)' is missing sourcePort"
+    }
+
+    $lines = New-Object System.Collections.Generic.List[string]
+    $lines.Add("# Generated by start-sdrtrunk-feeds.ps1. Edit the master feed YAML instead.")
+    $lines.Add("")
+    $lines.Add("daemon:")
+    $lines.Add("    name: $(ConvertTo-Rc2YamlString $name)")
+    $lines.Add("    desc: $(ConvertTo-Rc2YamlString $desc)")
+    $lines.Add("    listenAddress: $rc2ListenAddress")
+    $lines.Add("    listenPort: $rc2Port")
+    $lines.Add("")
+    $lines.Add("audio:")
+    $lines.Add("    txDevice: `"`"")
+    $lines.Add("    rxDevice: `"`"")
+    $lines.Add("")
+    $lines.Add("control:")
+    $lines.Add("    controlMode: 5")
+    $lines.Add("    rxOnly: true")
+    $lines.Add("")
+    $lines.Add("    sdrTrunk:")
+    $lines.Add("        listenAddress: $sourceListenAddress")
+    $lines.Add("        listenPort: $sourcePort")
+    $lines.Add("        mount: $(ConvertTo-Rc2YamlString $mount)")
+    $lines.Add("        sourcePassword: $(ConvertTo-Rc2YamlString $sourcePassword)")
+    $lines.Add("        zoneName: $(ConvertTo-Rc2YamlString $zoneName)")
+    $lines.Add("        channelName: $(ConvertTo-Rc2YamlString $channelName)")
+    $lines.Add("        rxThresholdDb: $rxThresholdDb")
+    $lines.Add("        attackMs: $attackMs")
+    $lines.Add("        hangMs: $hangMs")
+    $lines.Add("        outputSampleRate: $outputSampleRate")
+    if ($emitSourceNoAudioRestartMs) {
+        $lines.Add("        sourceNoAudioRestartMs: $sourceNoAudioRestartMs")
+    }
+    $lines.Add("")
+    $lines.Add("softkeys:")
+    foreach ($softkey in $softkeys) {
+        $lines.Add("    - $softkey")
+    }
+
+    $directory = Split-Path -Parent $Path
+    if (-not (Test-Path -LiteralPath $directory)) {
+        New-Item -ItemType Directory -Path $directory -Force | Out-Null
+    }
+
+    Set-Content -LiteralPath $Path -Value $lines -Encoding UTF8
+}
+
+function Assert-Rc2UniqueFeedPorts {
+    param(
+        [array]$Feeds,
+        [System.Collections.IDictionary]$Defaults
+    )
+
+    $rc2Ports = @{}
+    $sourcePorts = @{}
+
+    foreach ($feed in $Feeds) {
+        $id = [string]$feed.id
+        $rc2Port = Get-Rc2Value $feed $Defaults "rc2Port" $null
+        $sourcePort = Get-Rc2Value $feed $Defaults "sourcePort" $null
+
+        if ($null -eq $rc2Port) {
+            throw "Feed '$id' is missing rc2Port"
+        }
+
+        if ($null -eq $sourcePort) {
+            throw "Feed '$id' is missing sourcePort"
+        }
+
+        $rc2Key = [string]$rc2Port
+        if ($rc2Ports.ContainsKey($rc2Key)) {
+            throw "Duplicate rc2Port ${rc2Port}: feeds '$($rc2Ports[$rc2Key])' and '$id' cannot both use the same RC2 websocket port"
+        }
+
+        $sourceKey = [string]$sourcePort
+        if ($sourcePorts.ContainsKey($sourceKey)) {
+            throw "Duplicate sourcePort ${sourcePort}: feeds '$($sourcePorts[$sourceKey])' and '$id' cannot both use the same SDRTrunk source port"
+        }
+
+        $rc2Ports[$rc2Key] = $id
+        $sourcePorts[$sourceKey] = $id
+    }
+}
+
+function Test-Rc2Property {
+    param($Object, [string]$Name)
+    return $null -ne $Object -and $Object.PSObject.Properties.Name -contains $Name
+}
+
+function Get-Rc2ObjectProperty {
+    param($Object, [string]$Name, $Fallback = $null)
+    if (Test-Rc2Property $Object $Name) {
+        return $Object.$Name
+    }
+
+    return $Fallback
+}
+
+function Set-Rc2ObjectProperty {
+    param($Object, [string]$Name, $Value)
+    if (Test-Rc2Property $Object $Name) {
+        $Object.$Name = $Value
+    }
+    else {
+        $Object | Add-Member -MemberType NoteProperty -Name $Name -Value $Value
+    }
+}
+
+function Write-Rc2Utf8NoBom {
+    param(
+        [string]$Path,
+        [string]$Text
+    )
+
+    $encoding = New-Object System.Text.UTF8Encoding($false)
+    [System.IO.File]::WriteAllText($Path, $Text, $encoding)
+}
+
+function Get-Rc2ConsoleConfigPath {
+    param(
+        [System.Collections.IDictionary]$LauncherConfig,
+        [System.Collections.IDictionary]$Defaults,
+        [string]$ConfigDirectory,
+        [string]$OverridePath
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($OverridePath)) {
+        return Resolve-Rc2Path $OverridePath (Get-Location).Path
+    }
+
+    $configuredPath = Get-Rc2Value $LauncherConfig $Defaults "rc2ConfigPath" $null
+    if (-not [string]::IsNullOrWhiteSpace([string]$configuredPath)) {
+        return Resolve-Rc2Path $configuredPath $ConfigDirectory
+    }
+
+    $roamingRoot = [Environment]::GetFolderPath("ApplicationData")
+    $defaultPath = Join-Path $roamingRoot "rc2-console\config.json"
+    $alternatePath = Join-Path $roamingRoot "RadioConsole2 GUI\config.json"
+    if (Test-Path -LiteralPath $defaultPath) {
+        return $defaultPath
+    }
+    if (Test-Path -LiteralPath $alternatePath) {
+        return $alternatePath
+    }
+
+    return $defaultPath
+}
+
+function New-Rc2DefaultConsoleConfig {
+    return [pscustomobject]@{
+        Radios = @()
+        Autoconnect = $false
+        ClockFormat = "UTC"
+        Audio = [pscustomobject]@{
+            ButtonSounds = $true
+            UnselectedVol = -9.0
+            ToneVolume = -9.0
+            UseAGC = $true
+        }
+        Extension = [pscustomobject]@{
+            address = "127.0.0.1"
+            port = 5555
+        }
+        Peripherals = [pscustomobject]@{
+            serialPort = ""
+            useCtsForPtt = $false
+        }
+        Midi = [pscustomobject]@{
+            port = -1
+            enabled = $false
+            ccs = [pscustomobject]@{
+                masterPtt = [pscustomobject]@{ chan = $null; num = $null }
+                masterVol = [pscustomobject]@{ chan = $null; num = $null }
+            }
+        }
+    }
+}
+
+function New-Rc2ConsoleRadio {
+    param(
+        [System.Collections.IDictionary]$Feed,
+        [System.Collections.IDictionary]$Defaults
+    )
+
+    $name = Get-Rc2Value $Feed $Defaults "consoleName" (Get-Rc2Value $Feed $Defaults "name" $Feed.id)
+    $address = Get-Rc2Value $Feed $Defaults "rc2Address" "127.0.0.1"
+    $port = Get-Rc2Value $Feed $Defaults "rc2Port" $null
+    $color = Get-Rc2Value $Feed $Defaults "color" "blue"
+    $pan = Get-Rc2Value $Feed $Defaults "pan" 0
+    if ($null -eq $port) {
+        throw "Feed '$($Feed.id)' is missing rc2Port"
+    }
+
+    return [pscustomobject][ordered]@{
+        name = [string]$name
+        address = [string]$address
+        port = [int]$port
+        color = [string]$color
+        pan = [double]$pan
+        managedBy = "sdrtrunk-feeds"
+        sdrTrunkFeedId = [string]$Feed.id
+    }
+}
+
+function New-Rc2PersistedRadio {
+    param($Radio)
+
+    $persisted = [ordered]@{
+        name = [string](Get-Rc2ObjectProperty $Radio "name" "")
+        address = [string](Get-Rc2ObjectProperty $Radio "address" "127.0.0.1")
+        port = Get-Rc2ObjectProperty $Radio "port" 0
+        color = [string](Get-Rc2ObjectProperty $Radio "color" "blue")
+        pan = Get-Rc2ObjectProperty $Radio "pan" 0
+    }
+
+    if ((Get-Rc2ObjectProperty $Radio "managedBy" "") -eq "sdrtrunk-feeds") {
+        $persisted.managedBy = "sdrtrunk-feeds"
+        $persisted.sdrTrunkFeedId = [string](Get-Rc2ObjectProperty $Radio "sdrTrunkFeedId" "")
+    }
+
+    return [pscustomobject]$persisted
+}
+
+function New-Rc2CleanConsoleConfig {
+    param($ConsoleConfig, [array]$Radios)
+
+    $defaults = New-Rc2DefaultConsoleConfig
+
+    return [pscustomobject][ordered]@{
+        Radios = @($Radios | ForEach-Object { New-Rc2PersistedRadio $_ })
+        Autoconnect = Get-Rc2ObjectProperty $ConsoleConfig "Autoconnect" $defaults.Autoconnect
+        ClockFormat = Get-Rc2ObjectProperty $ConsoleConfig "ClockFormat" $defaults.ClockFormat
+        Audio = Get-Rc2ObjectProperty $ConsoleConfig "Audio" $defaults.Audio
+        Extension = Get-Rc2ObjectProperty $ConsoleConfig "Extension" $defaults.Extension
+        Peripherals = Get-Rc2ObjectProperty $ConsoleConfig "Peripherals" $defaults.Peripherals
+        Midi = Get-Rc2ObjectProperty $ConsoleConfig "Midi" $defaults.Midi
+    }
+}
+
+function Update-Rc2ConsoleConfig {
+    param(
+        [string]$Path,
+        [array]$Feeds,
+        [System.Collections.IDictionary]$Defaults
+    )
+
+    $directory = Split-Path -Parent $Path
+    if (-not (Test-Path -LiteralPath $directory)) {
+        New-Item -ItemType Directory -Path $directory -Force | Out-Null
+    }
+
+    if (Test-Path -LiteralPath $Path) {
+        $timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+        $backupPath = "$Path.bak-$timestamp"
+        Copy-Item -LiteralPath $Path -Destination $backupPath -Force
+        $consoleConfig = (Get-Content -LiteralPath $Path -Raw) | ConvertFrom-Json
+        Write-Host "Backed up RC2 console config to $backupPath"
+    }
+    else {
+        $consoleConfig = New-Rc2DefaultConsoleConfig
+        Write-Host "Creating RC2 console config at $Path"
+    }
+
+    if (-not (Test-Rc2Property $consoleConfig "Radios") -or $null -eq $consoleConfig.Radios) {
+        Set-Rc2ObjectProperty $consoleConfig "Radios" @()
+    }
+
+    $desiredRadios = @{}
+    foreach ($feed in $Feeds) {
+        $radio = New-Rc2ConsoleRadio $feed $Defaults
+        $desiredRadios[[string]$feed.id] = $radio
+    }
+
+    $updatedRadios = New-Object System.Collections.Generic.List[object]
+    foreach ($radio in @($consoleConfig.Radios)) {
+        $managedBy = Get-Rc2ObjectProperty $radio "managedBy" ""
+        $feedId = [string](Get-Rc2ObjectProperty $radio "sdrTrunkFeedId" "")
+
+        if ($managedBy -eq "sdrtrunk-feeds") {
+            if ($desiredRadios.ContainsKey($feedId)) {
+                continue
+            }
+            continue
+        }
+
+        $updatedRadios.Add($radio)
+    }
+
+    foreach ($radio in $desiredRadios.Values) {
+        $updatedRadios.Add($radio)
+    }
+
+    $cleanConfig = New-Rc2CleanConsoleConfig $consoleConfig @($updatedRadios.ToArray())
+    $json = $cleanConfig | ConvertTo-Json -Depth 100
+    Write-Rc2Utf8NoBom $Path $json
+    Write-Host "Updated RC2 console config with $($desiredRadios.Count) SDRTrunk radio(s): $Path"
+}
+
+function New-Rc2KillOnCloseJob {
+    if ($env:OS -ne "Windows_NT") {
+        return [IntPtr]::Zero
+    }
+
+    Add-Type -TypeDefinition @"
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+public static class Rc2JobObject
+{
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern IntPtr CreateJobObject(IntPtr lpJobAttributes, string lpName);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool SetInformationJobObject(IntPtr hJob, int infoClass, IntPtr lpJobObjectInfo, uint cbJobObjectInfoLength);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern bool AssignProcessToJobObject(IntPtr hJob, IntPtr hProcess);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern bool CloseHandle(IntPtr hObject);
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct JOBOBJECT_BASIC_LIMIT_INFORMATION
+    {
+        public long PerProcessUserTimeLimit;
+        public long PerJobUserTimeLimit;
+        public uint LimitFlags;
+        public UIntPtr MinimumWorkingSetSize;
+        public UIntPtr MaximumWorkingSetSize;
+        public uint ActiveProcessLimit;
+        public UIntPtr Affinity;
+        public uint PriorityClass;
+        public uint SchedulingClass;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct IO_COUNTERS
+    {
+        public ulong ReadOperationCount;
+        public ulong WriteOperationCount;
+        public ulong OtherOperationCount;
+        public ulong ReadTransferCount;
+        public ulong WriteTransferCount;
+        public ulong OtherTransferCount;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+    {
+        public JOBOBJECT_BASIC_LIMIT_INFORMATION BasicLimitInformation;
+        public IO_COUNTERS IoInfo;
+        public UIntPtr ProcessMemoryLimit;
+        public UIntPtr JobMemoryLimit;
+        public UIntPtr PeakProcessMemoryUsed;
+        public UIntPtr PeakJobMemoryUsed;
+    }
+
+    private const int JobObjectExtendedLimitInformation = 9;
+    private const uint JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x00002000;
+
+    public static IntPtr CreateKillOnCloseJob(string name)
+    {
+        IntPtr job = CreateJobObject(IntPtr.Zero, name);
+        if (job == IntPtr.Zero)
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        JOBOBJECT_EXTENDED_LIMIT_INFORMATION info = new JOBOBJECT_EXTENDED_LIMIT_INFORMATION();
+        info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+
+        int length = Marshal.SizeOf(typeof(JOBOBJECT_EXTENDED_LIMIT_INFORMATION));
+        IntPtr pointer = Marshal.AllocHGlobal(length);
+        try
+        {
+            Marshal.StructureToPtr(info, pointer, false);
+            if (!SetInformationJobObject(job, JobObjectExtendedLimitInformation, pointer, (uint)length))
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(pointer);
+        }
+
+        return job;
+    }
+}
+"@
+
+    return [Rc2JobObject]::CreateKillOnCloseJob("RadioConsole2-SDRTrunk-$PID")
+}
+
+function Stop-Rc2FeedProcesses {
+    param($Processes)
+
+    foreach ($entry in $Processes) {
+        $process = $entry.Process
+        if ($null -eq $process -or $process.HasExited) {
+            continue
+        }
+
+        Write-Host "Stopping $($entry.Id) (PID $($process.Id))"
+        try {
+            Stop-Process -Id $process.Id -Force -ErrorAction Stop
+        }
+        catch {
+            Write-Warning "Unable to stop $($entry.Id): $($_.Exception.Message)"
+        }
+    }
+}
+
+$configPath = Resolve-Rc2LauncherConfigPath $Config
+if (-not (Test-Path -LiteralPath $configPath)) {
+    throw "Config file not found: $configPath"
+}
+
+$configDirectory = Split-Path -Parent $configPath
+$launcherConfig = ConvertFrom-Rc2FeedYaml $configPath
+$defaults = $launcherConfig.defaults
+
+if ($DaemonPath) {
+    $daemonExe = Resolve-Rc2Path $DaemonPath (Get-Location).Path
+}
+else {
+    $daemonExe = Resolve-Rc2Path (Get-Rc2Value $launcherConfig $defaults "daemonPath" ".\daemon.exe") $configDirectory
+}
+
+if (-not (Test-Path -LiteralPath $daemonExe) -and -not $GenerateOnly) {
+    throw "Daemon executable not found: $daemonExe"
+}
+
+$generatedDirectory = Resolve-Rc2Path (Get-Rc2Value $launcherConfig $defaults "generatedConfigDirectory" ".\generated-sdrtrunk") $configDirectory
+$logDirectory = Resolve-Rc2Path (Get-Rc2Value $launcherConfig $defaults "logDirectory" ".\logs") $configDirectory
+$debugDaemons = [bool](Get-Rc2Value $launcherConfig $defaults "debug" $false)
+$enabledFeeds = @($launcherConfig.feeds | Where-Object { -not $_.Contains("enabled") -or [bool]$_.enabled })
+
+if ($enabledFeeds.Count -eq 0) {
+    throw "No enabled feeds found in $configPath"
+}
+
+Assert-Rc2UniqueFeedPorts $enabledFeeds $defaults
+
+New-Item -ItemType Directory -Path $generatedDirectory -Force | Out-Null
+New-Item -ItemType Directory -Path $logDirectory -Force | Out-Null
+
+$feedConfigs = @()
+foreach ($feed in $enabledFeeds) {
+    if (-not $feed.Contains("id") -or [string]::IsNullOrWhiteSpace([string]$feed.id)) {
+        throw "Every feed must have an id"
+    }
+
+    $feedConfigPath = Join-Path $generatedDirectory "$($feed.id).yml"
+    Write-Rc2DaemonConfig $feed $defaults $feedConfigPath
+    $feedConfigs += [pscustomobject]@{
+        Id = $feed.id
+        ConfigPath = $feedConfigPath
+        Rc2Port = Get-Rc2Value $feed $defaults "rc2Port"
+        SourcePort = Get-Rc2Value $feed $defaults "sourcePort"
+    }
+}
+
+Write-Host "Generated $($feedConfigs.Count) daemon config(s) in $generatedDirectory"
+
+if ($GenerateOnly) {
+    return
+}
+
+$updateRc2Config = [bool](Get-Rc2Value $launcherConfig $defaults "updateRc2Config" $true)
+if ($updateRc2Config -and -not $NoRc2ConfigUpdate) {
+    $consoleConfigPath = Get-Rc2ConsoleConfigPath $launcherConfig $defaults $configDirectory $Rc2ConfigPath
+    Update-Rc2ConsoleConfig $consoleConfigPath $enabledFeeds $defaults
+}
+
+$jobHandle = [IntPtr]::Zero
+if (-not $NoJobObject) {
+    try {
+        $jobHandle = New-Rc2KillOnCloseJob
+        if ($jobHandle -ne [IntPtr]::Zero) {
+            Write-Host "Started Windows job group. Closing this launcher will stop all child daemons."
+        }
+    }
+    catch {
+        Write-Warning "Could not create Windows job group: $($_.Exception.Message)"
+        Write-Warning "Ctrl+C will still stop children while this launcher is running."
+    }
+}
+
+$startedProcesses = @()
+$script:Stopping = $false
+$cancelHandler = [System.ConsoleCancelEventHandler]{
+    param($sender, $eventArgs)
+    $eventArgs.Cancel = $true
+    $script:Stopping = $true
+    Write-Host ""
+    Write-Host "Stopping SDRTrunk daemon group..."
+}
+
+[System.Console]::add_CancelKeyPress($cancelHandler)
+
+try {
+    foreach ($feedConfig in $feedConfigs) {
+        $stdoutPath = Join-Path $logDirectory "$($feedConfig.Id).out.log"
+        $stderrPath = Join-Path $logDirectory "$($feedConfig.Id).err.log"
+        $arguments = @("-c", $feedConfig.ConfigPath)
+        if ($debugDaemons) {
+            $arguments += "-d"
+        }
+
+        Write-Host "Starting $($feedConfig.Id): RC2 $($feedConfig.Rc2Port), SDRTrunk $($feedConfig.SourcePort)"
+        $process = Start-Process `
+            -FilePath $daemonExe `
+            -ArgumentList $arguments `
+            -WorkingDirectory (Split-Path -Parent $daemonExe) `
+            -RedirectStandardOutput $stdoutPath `
+            -RedirectStandardError $stderrPath `
+            -WindowStyle Hidden `
+            -PassThru
+
+        if ($jobHandle -ne [IntPtr]::Zero) {
+            if (-not [Rc2JobObject]::AssignProcessToJobObject($jobHandle, $process.Handle)) {
+                Write-Warning "Could not add $($feedConfig.Id) to job group. It may need manual cleanup if the launcher exits unexpectedly."
+            }
+        }
+
+        $startedProcesses += [pscustomobject]@{
+            Id = $feedConfig.Id
+            Process = $process
+            StdOut = $stdoutPath
+            StdErr = $stderrPath
+        }
+    }
+
+    Write-Host ""
+    Write-Host "All feeds are running. Press Ctrl+C to stop them."
+    Write-Host "Logs are in $logDirectory"
+
+    while (-not $script:Stopping) {
+        $running = @($startedProcesses | Where-Object { -not $_.Process.HasExited })
+        if ($running.Count -eq 0) {
+            Write-Host "All daemon processes exited."
+            break
+        }
+
+        Start-Sleep -Seconds 1
+    }
+}
+finally {
+    Stop-Rc2FeedProcesses $startedProcesses
+
+    if ($jobHandle -ne [IntPtr]::Zero) {
+        [Rc2JobObject]::CloseHandle($jobHandle) | Out-Null
+    }
+
+    [System.Console]::remove_CancelKeyPress($cancelHandler)
+}


### PR DESCRIPTION
## Summary

This PR adds a new SDRTrunk daemon mode that lets RadioConsole2 receive live SDRTrunk audio through an Icecast-compatible source connection.

The daemon can now act as a lightweight Icecast-style ingest point for SDRTrunk, decode the incoming MP3 stream, forward the audio into RC2 over the normal WebRTC path, and update the console display from SDRTrunk metadata.

## What Changed

- Added new `SDRTrunk` control mode.
- Added an Icecast-compatible source listener for SDRTrunk.
- Added direct MP3 stream decoding for live SDRTrunk audio.
- Added support for SDRTrunk metadata updates, including inline Icecast metadata and `/admin/metadata` updates.
- Added RX-only WebRTC handling for stream-based radios.
- Added receive-state gating based on audio level and metadata activity.
- Added stale source recovery so the daemon can close and restart a connected SDRTrunk source if it stops producing decodable audio.
- Added example SDRTrunk configuration.

## Notes

This mode is intended for SDRTrunk’s streaming/broadcast output. SDRTrunk should be configured to publish to the daemon as an Icecast source, using the configured mount point such as `/sdrtrunk`.

The daemon does not require a separate Icecast server for this path; it provides the source listener directly and presents the stream to RC2 as a receive-only radio.

## Testing

- Verified daemon builds successfully.
- Tested SDRTrunk source connections against the new Icecast-compatible listener.
- Tested live audio forwarding into RC2.
- Tested SDRTrunk metadata handling with inline metadata and admin metadata updates.